### PR TITLE
Updated sprockets to version 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ PATH
       rugged (~> 0.23.3)
       sass-rails (~> 5.0)
       simplecov (~> 0.9.1)
-      sprockets (~> 2.8)
+      sprockets (~> 3.0)
       strongbox (~> 0.7.2)
       thor
       thread_safe (~> 0.3.5)
@@ -120,6 +120,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
+    concurrent-ruby (1.0.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     css_parser (1.3.7)
@@ -177,7 +178,6 @@ GEM
       tilt (~> 1.2)
     hashdiff (0.2.3)
     highline (1.6.21)
-    hike (1.2.3)
     houston-devise_ldap_authenticatable (0.7.1)
       devise (>= 3.0.0)
       net-ldap (~> 0.12.1)
@@ -320,15 +320,13 @@ GEM
       json
       simplecov
     slop (3.6.0)
-    sprockets (2.12.4)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets (3.5.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.0.4)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     strongbox (0.7.2)
       activerecord
     test_after_commit (0.4.2)

--- a/houston.gemspec
+++ b/houston.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   # For Houston as a Web Application
   spec.add_dependency "rails", "~> 4.2.5.1"
-  spec.add_dependency "sprockets", "~> 2.8" # update this when updating Rails
+  spec.add_dependency "sprockets", "~> 3.0" # update this when updating Rails
   spec.add_dependency "pg", "~> 0.18.3"
   # --------------------------------
   spec.add_dependency "activerecord-import"


### PR DESCRIPTION
Sprockets `~> 3` fixes a bug where assets were being compiled _every_ time, no matter if they'd been edited. Heroku released a [blog post](https://engineering.heroku.com/blogs/2016-02-18-speeding-up-sprockets/) with more information.