### PR TITLE
Improve Houston startup experience

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
   <%= "mobile" if mobile? %>">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
     <title><%= title %></title>
     <%= csrf_meta_tags %>
     <%= action_cable_meta_tag %>

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -9,7 +9,7 @@
 
 # Make sure your secret_key_base is kept private
 # if you're sharing your code publicly.
-if Rails.env.test?
+unless Rails.env.production?
   Houston::Application.config.secret_key_base = "8cf48c792d860953a74ecaa7c779c6019ecddf39a03300a9aed505662f519cf933b4b0ecba3bea4f0eaaf3debd09b08c3e2bd87b9d30be8df0b1166ab4962752"
 else
   Houston::Application.config.secret_key_base = ENV["HOUSTON_SECRET_KEY_BASE"]

--- a/lib/generators/instance_generator.rb
+++ b/lib/generators/instance_generator.rb
@@ -10,8 +10,6 @@ module Generators
     argument :app_path, type: :string
 
     def copy_files
-      copy_file ".gitignore", "#{app_path}/.gitignore"
-
       path = source_paths[0]
       path_length = path.length + 1
       Dir.glob(path + "/**/*", File::FNM_DOTMATCH).each do |file|

--- a/lib/generators/instance_generator.rb
+++ b/lib/generators/instance_generator.rb
@@ -27,7 +27,7 @@ module Generators
     end
 
     def name
-      app_path
+      File.basename(app_path)
     end
 
   end

--- a/lib/generators/instance_generator.rb
+++ b/lib/generators/instance_generator.rb
@@ -14,7 +14,7 @@ module Generators
 
       path = source_paths[0]
       path_length = path.length + 1
-      Dir.glob(path + "/**/*").each do |file|
+      Dir.glob(path + "/**/*", File::FNM_DOTMATCH).each do |file|
         next if File.directory?(file)
         path = file[path_length..-1]
         template path, "#{app_path}/#{path}"

--- a/templates/new-instance/config/main.rb
+++ b/templates/new-instance/config/main.rb
@@ -134,8 +134,8 @@ Houston.config do
   #
   # To create a new module for Houston, run:
   #
-  #   gem install houston-cli
-  #   houston_new_module <MODULE>
+  #
+  #   houston new --module <MODULE>
   #
   # Then add the module to your Gemfile with:
   #


### PR DESCRIPTION
With these changes, you should now be able to follow the README and be up and running with:

```
houston new ~/path/to/my-houston
cd my-houston
bin/setup
bundle exec rails server
```

These are all one line commits so I'm definitely game to squash them. I just wanted to show the whole story before doing that.