### PR TITLE
[skip] When not browser focused on a view that refreshes, don’t refresh

### DIFF
--- a/app/assets/javascripts/houston/dashboard/refresher.coffee
+++ b/app/assets/javascripts/houston/dashboard/refresher.coffee
@@ -9,6 +9,7 @@ class @Refresher
     @innerRadius = @width / 3
     @outerRadius = @width / 2
     @_container = 'body'
+    @$window = $(window)
 
   rate: (@_rate)-> @
   container: (@_container)-> @
@@ -46,7 +47,9 @@ class @Refresher
       .attr('d', @arc)
 
     @tween = _.bind(@arcTween, @)
-    setInterval(_.bind(@tick, @), @_rate)
+    @tickInterval = setInterval(_.bind(@tick, @), @_rate)
+    @$window.on "blur", => clearInterval(@tickInterval)
+    @$window.on "focus", => @restart()
     @start()
 
   start: ->
@@ -60,11 +63,15 @@ class @Refresher
         .ease('linear')
         .call(@tween, (@_rate / @_interval) * τ)
 
+  restart: ->
+    @_callback() if @_callback
+    @tickInterval = setInterval(_.bind(@tick, @), @_rate)
+    @start()
+
   tick: ->
     time = +(new Date())
     if time > @_endTime
-      @_callback() if @_callback
-      @start()
+      @restart()
     else
       percent = (time + @_rate - @_startTime) / @_interval
       @foreground.transition()


### PR DESCRIPTION
This would halt the ticker when you’re not currently looking at a view that does polling. Regaining focus calls the given callback and restarts the view.

If you don't think this is a good idea or needs improvement, just comment on this. Thanks