### PR TITLE
Ran actions asynchronously with ActiveJob rather than `Houston.async`

### DIFF
--- a/app/jobs/action_runner.rb
+++ b/app/jobs/action_runner.rb
@@ -1,0 +1,43 @@
+class ActionRunner < ApplicationJob
+  queue_as :default
+
+  def perform(action)
+    exception = nil
+
+    Houston.reconnect do
+      action.touch :started_at
+      Houston.actions.fetch(action.name).execute(action.params)
+    end
+
+  rescue *::Action.ignored_exceptions
+
+    # Note that the action failed, but do not report _these_ exceptions
+    exception = $!
+
+  rescue Exception # rescues StandardError by default; but we want to rescue and report all errors
+
+    # Report all other exceptions
+    exception = $!
+    Houston.report_exception($!, parameters: {
+      action_id: action.id,
+      action_name: action.name,
+      trigger: action.trigger,
+      params: action.params
+    })
+
+  ensure
+    begin
+      Houston.reconnect do
+        action.finish! exception
+      end
+    rescue Exception # rescues StandardError by default; but we want to rescue and report all errors
+      Houston.report_exception($!, parameters: {
+        action_id: action.id,
+        action_name: action.name,
+        trigger: action.trigger,
+        params: action.params
+      })
+    end
+  end
+
+end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,2 @@
+class ApplicationJob < ActiveJob::Base
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,4 +69,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.active_job.queue_adapter = :async
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,4 +89,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.active_job.queue_adapter = :async
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.active_job.queue_adapter = :inline
 end

--- a/lib/houston/boot/actions.rb
+++ b/lib/houston/boot/actions.rb
@@ -69,9 +69,7 @@ module Houston
       assert_required_params! action, params
       assert_serializable! params
 
-      Houston.async(options.fetch(:async, true)) do
-        ::Action.run! name, params, options.fetch(:trigger, "manual")
-      end
+      ::Action.run! name, params, options.fetch(:trigger, "manual")
     end
 
 

--- a/lib/houston/boot/triggers.rb
+++ b/lib/houston/boot/triggers.rb
@@ -6,11 +6,9 @@ module Houston
 
   class Triggers < SimpleDelegator
     attr_reader :config
-    attr_accessor :async
 
     def initialize(config)
       @config = config
-      @async = true
       super Concurrent::Array.new
     end
 
@@ -71,9 +69,7 @@ module Houston
 
     def call(params={})
       Rails.logger.info "\e[34m[#{to_s} => #{action}]\e[0m"
-      config.actions.run action, self.params.merge(params.to_h),
-        trigger: to_s,
-        async: triggers.async
+      config.actions.run action, self.params.merge(params.to_h), trigger: to_s
     end
 
     def to_s

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,7 +27,6 @@ end
 
 
 Houston.observer.async = false
-Houston.triggers.async = false
 
 
 

--- a/test/unit/models/actions_test.rb
+++ b/test/unit/models/actions_test.rb
@@ -107,7 +107,7 @@ private
   end
 
   def run!(params={}, options={})
-    actions.run "test-action", params, options.merge(async: false)
+    actions.run "test-action", params, options
   end
 
 end


### PR DESCRIPTION
This has three benefits:
  1. The Active Job Async adapter runs jobs in a thread pool.
  2. It’s now much easier to move to using a backend like Sidekiq instead of threads.
  3. Leveraging Active Job allows Houston instances to choose the right backend for them.
