### PR TITLE
Updated Devise reset password token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem "timecop"
   gem "rr"
   gem "webmock", require: "webmock/minitest"
-  gem "factory_girl_rails", "4.8.0"
+  gem "factory_girl_rails", "4.9.0"
   gem "launchy"
 
   # For Jenkins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,10 +124,10 @@ GEM
     et-orbi (1.0.7)
       tzinfo
     execjs (2.7.0)
-    factory_girl (4.8.2)
+    factory_girl (4.9.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_girl_rails (4.9.0)
+      factory_girl (~> 4.9.0)
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -302,7 +302,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
-  factory_girl_rails (= 4.8.0)
+  factory_girl_rails (= 4.9.0)
   houston-core!
   launchy
   minitest

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password, and you can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @resource.reset_password_token) %></p>
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>


### PR DESCRIPTION
Updated reset password token to reflect [changes made in v.3.1.0](https://github.com/plataformatec/devise/commit/143794d701bcd7b8c900c5bb8a216026c3c68afc) when the token was moved from `@resource` to its own instance variable.
