### PR TITLE
Verified connections obtained when performing async operations

### DIFF
--- a/config/initializers/houston_async.rb
+++ b/config/initializers/houston_async.rb
@@ -4,7 +4,8 @@ module Houston
   def self.async(do_async=true)
     return yield unless do_async
     Thread.new do
-      ActiveRecord::Base.connection_pool.with_connection do
+      ActiveRecord::Base.connection_pool.with_connection do |connection|
+        connection.verify!
         begin
           yield
         rescue Exception # rescues StandardError by default; but we want to rescue and report all errors
@@ -20,7 +21,8 @@ module Houston
   def self.async!(do_async=true)
     return yield unless do_async
     Thread.new do
-      ActiveRecord::Base.connection_pool.with_connection do
+      ActiveRecord::Base.connection_pool.with_connection do |connection|
+        connection.verify!
         begin
           yield
         ensure


### PR DESCRIPTION
Async operations are sometimes failing with `PG::ConnectionBad: PQsocket() can't get socket descriptor.` Verifying the connection before using it _should_ eliminate this error by ensuring that the connection we've gotten is still usable before using it.