### PR TITLE
Unlocked addressable to address CVE

### DIFF
--- a/houston-core.gemspec
+++ b/houston-core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pg", "~> 1.2.0"
   # --------------------------------
   spec.add_dependency "activerecord-import"
-  spec.add_dependency "addressable", "~> 2.3.8" # <-- 2.5.0 raises "invalid scheme format" for "git@github.com"
+  spec.add_dependency "addressable"
   spec.add_dependency "attentive", ">= 0.3.9"
   spec.add_dependency "browser", "~> 2.3.0"
   spec.add_dependency "cancancan", ">= 3.0.0"


### PR DESCRIPTION
### Summary
Addressable has a vulnerability between 2.3 and 2.7 inclusive. We were locked to 2.3 becasue of `houston-commits`, but a sister PR updated that gem to be able to work with newer versions of `addressable`.