### PR TITLE
Fixed creating a project with updated version of cancancan

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -78,6 +78,7 @@ private
     attrs[:selected_features] ||= []
     attrs
   end
+  alias project_params project_attributes
 
 
   def convert_maintainers_attributes_to_maintainer_ids


### PR DESCRIPTION
Not sure how this was working before, but cancancan automatically tries to create and authorize an instance of Project from the params before the create action; however, unless it knows to call the `project_attributes` method, it will try to create an instance with un-permitted parameter attributes, causing an error.

Cancancan knows to look for `{resource}_params`, though, so a simple alias fixes the issue.