### PR TITLE
Actually wait for scheduler to start

### DIFF
--- a/lib/houston/boot/daemonize.rb
+++ b/lib/houston/boot/daemonize.rb
@@ -14,6 +14,7 @@ module Houston
         connected_at = Time.now
         Houston.observer.fire "daemon:#{name}:start"
         yield
+        Houston.observer.fire "daemon:#{name}:started"
 
       rescue Exception
         puts "\e[91m#{$!.class}: #{$!.message}\e[0m" if Rails.env.development?

--- a/lib/houston/boot/extensions.rb
+++ b/lib/houston/boot/extensions.rb
@@ -74,7 +74,8 @@ module Houston
     .ability { |project| can?(:update, project) }
 
   register_events {{
-    "daemon:{type}:start"   => desc("Daemon {type} has started"),
+    "daemon:{type}:start"   => desc("Daemon {type} is starting"),
+    "daemon:{type}:started" => desc("Daemon {type} has started"),
     "daemon:{type}:restart" => desc("Daemon {type} has restarted"),
     "daemon:{type}:stop"    => desc("Daemon {type} has stopped"),
 

--- a/lib/houston/boot/timer.rb
+++ b/lib/houston/boot/timer.rb
@@ -34,7 +34,7 @@ module Houston
     def initialize
       @queued_timers = Concurrent::Array.new
 
-      Houston.observer.on "daemon:scheduler:start", raise: true do
+      Houston.observer.on "daemon:scheduler:started", raise: true do
         schedule_queued_timers!
       end
     end


### PR DESCRIPTION
### Summary
The Houston observer event is fired _before_ the call to start the daemon, setting up a potential race condition. We should wait to listen for an event _after_ the call to start the daemon to ensure no queued timers get dropped.