### PR TITLE
Beltic verifiable-credentials integration (scaffold)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ BELTIC_WEBHOOK_SECRET=
 #   bin/rails beltic:bootstrap_business_credential
 # This becomes parent_business_id on every user/agent credential Houston issues.
 BELTIC_ORG_CREDENTIAL_ID=
+
+# Master key for at-rest encryption of VerifiableCredential#signed_payload via Lockbox.
+# Generate with: bundle exec rake "lockbox:generate_key"
+# In production, prefer Rails encrypted credentials over a plain ENV var.
+LOCKBOX_MASTER_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Houston environment variables — copy to .env or set in your deploy environment.
+
+# === Beltic Verifiable Credentials integration ===
+# See docs/integrations/beltic.md for the full pipeline.
+
+# Beltic API key for issuing/verifying credentials. Required.
+# Obtain from the Beltic Console — scope to `credentials:write,credentials:read,credentials:revoke,credentials:verify`.
+BELTIC_API_KEY=
+
+# Base URL for the Beltic credentials API. Defaults to production.
+# Use https://api.staging.beltic.com/v1 for staging.
+BELTIC_BASE_URL=https://api.beltic.com/v1
+
+# HMAC secret shared with Beltic for webhook signature verification.
+# Generate when you subscribe via POST /v1/audit/streams.
+BELTIC_WEBHOOK_SECRET=
+
+# Houston's own business credential ID, set after running the bootstrap rake task:
+#   bin/rails beltic:bootstrap_business_credential
+# This becomes parent_business_id on every user/agent credential Houston issues.
+BELTIC_ORG_CREDENTIAL_ID=

--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,13 @@ BELTIC_WEBHOOK_URL=
 # Generate with: bundle exec rake "lockbox:generate_key"
 # In production, prefer Rails encrypted credentials over a plain ENV var.
 LOCKBOX_MASTER_KEY=
+
+# Houston DB connection (defaults are fine for most setups). Override the port
+# if Postgres is on something other than 5432 — e.g., when running alongside
+# the Beltic platform's Docker Postgres on 5432, you'll want Houston's brew
+# Postgres on 5433.
+HOUSTON_DB_HOST=localhost
+HOUSTON_DB_PORT=5432
+
+# Rails session secret. Generate with: bundle exec rails secret
+HOUSTON_SECRET_KEY_BASE=

--- a/.env.example
+++ b/.env.example
@@ -4,21 +4,31 @@
 # See docs/integrations/beltic.md for the full pipeline.
 
 # Beltic API key for issuing/verifying credentials. Required.
-# Obtain from the Beltic Console — scope to `credentials:write,credentials:read,credentials:revoke,credentials:verify`.
+# Format: sk_staging_<32-char> or sk_production_<32-char>
+# Created via the Beltic Console with scopes: credentials:write, credentials:read,
+# credentials:revoke, credentials:verify. For local dev see LOCAL_DEV.md.
 BELTIC_API_KEY=
 
-# Base URL for the Beltic credentials API. Defaults to production.
-# Use https://api.staging.beltic.com/v1 for staging.
+# Base URL for the Beltic credentials API.
+# Production: https://api.beltic.com/v1
+# Staging:    https://api.staging.beltic.com/v1
+# Local Beltic platform (see LOCAL_DEV.md): http://localhost:8080/v1
 BELTIC_BASE_URL=https://api.beltic.com/v1
 
-# HMAC secret shared with Beltic for webhook signature verification.
-# Generate when you subscribe via POST /v1/audit/streams.
+# HMAC secret shared with Beltic for webhook signature verification (32+ chars).
+# Set this BEFORE running `bin/rails beltic:subscribe_webhooks` (the task will
+# generate one for you if missing and tell you what to set).
 BELTIC_WEBHOOK_SECRET=
 
-# Houston's own business credential ID, set after running the bootstrap rake task:
+# Houston's own business credential — set after running:
 #   bin/rails beltic:bootstrap_business_credential
-# This becomes parent_business_id on every user/agent credential Houston issues.
+# The rake task prints both values; copy them here.
 BELTIC_ORG_CREDENTIAL_ID=
+BELTIC_ORG_SUBJECT_ID=
+
+# Publicly-reachable URL that Beltic will POST webhook events to.
+# Used by `bin/rails beltic:subscribe_webhooks`. In dev, expose with `ngrok http 3000`.
+BELTIC_WEBHOOK_URL=
 
 # Master key for at-rest encryption of VerifiableCredential#signed_payload via Lockbox.
 # Generate with: bundle exec rake "lockbox:generate_key"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@
 # Ignore bundler config.
 /.bundle
 Gemfile.lock
+/vendor/bundle
+
+# Local environment overrides (secrets, DB port, etc.)
+/.env
+/.env.*
+!/.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/app/controllers/agent_authorizations_controller.rb
+++ b/app/controllers/agent_authorizations_controller.rb
@@ -1,0 +1,65 @@
+class AgentAuthorizationsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :load_agent
+
+  # GET /agents/:agent_id/authorization/new
+  # Renders the agent-authorization consent modal (Figma: "Authorize this agent").
+  def new
+    @user_credential = current_user.beltic_user_credential
+
+    unless @user_credential&.active?
+      redirect_to new_identity_verification_path,
+                  alert: "Verify your identity before authorizing an agent."
+      return
+    end
+  end
+
+  # POST /agents/:agent_id/authorization
+  def create
+    @agent.assign_attributes(agent_params)
+
+    if @agent.save
+      Beltic::IssueCredentialJob.perform_later(
+        kind:     :agent_authorization,
+        agent_id: @agent.id,
+      )
+      redirect_to settings_agents_path,
+                  notice: "Authorizing #{@agent.name}. Beltic is issuing the credential."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /agents/:agent_id/authorization
+  # Revokes the agent's current authorization credential. Idempotent.
+  def destroy
+    cred = @agent.authorization_credential
+    if cred
+      Houston::Beltic.issuer.revoke(cred.credential_id, reason: "revoked_by_user")
+      cred.update!(status: "revoked", revoked_at: Time.current)
+    end
+    @agent.update!(status: "revoked")
+
+    redirect_to settings_agents_path, notice: "#{@agent.name} revoked."
+  end
+
+  private
+
+  def load_agent
+    @agent = current_user.agents.find_or_initialize_by(id: params[:agent_id])
+  end
+
+  def agent_params
+    params.require(:agent).permit(
+      :name,
+      :spend_limit_amount_cents,
+      :spend_limit_currency,
+      :spend_limit_period,
+      :per_transaction_max_cents,
+      :max_idle_duration_iso8601,
+      :confirmation_threshold_cents,
+      :confirmation_mode,
+      authorized_currencies: [],
+    )
+  end
+end

--- a/app/controllers/agent_authorizations_controller.rb
+++ b/app/controllers/agent_authorizations_controller.rb
@@ -46,7 +46,7 @@ class AgentAuthorizationsController < ApplicationController
   private
 
   def load_agent
-    @agent = current_user.agents.find_or_initialize_by(id: params[:agent_id])
+    @agent = current_user.agents.find(params[:agent_id])
   end
 
   def agent_params

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -1,0 +1,57 @@
+class AgentsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_verified_identity
+
+  # GET /agents/new
+  # Renders the same form as agent_authorizations/new but for a brand-new agent.
+  def new
+    @agent = current_user.agents.build
+    @user_credential = current_user.beltic_user_credential
+    render "agent_authorizations/new"
+  end
+
+  # POST /agents
+  # Creates the Agent row, then enqueues Beltic agent_authorization issuance.
+  def create
+    @agent = current_user.agents.build(agent_params)
+    @agent.did = generate_did
+    @agent.status = "active"
+
+    if @agent.save
+      Beltic::IssueCredentialJob.perform_later(kind: :agent_authorization, agent_id: @agent.id)
+      redirect_to settings_agents_path,
+                  notice: "#{@agent.name} created. Beltic is issuing the authorization credential."
+    else
+      @user_credential = current_user.beltic_user_credential
+      render "agent_authorizations/new", status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def require_verified_identity
+    return if current_user.beltic_user_credential&.active?
+    redirect_to new_identity_verification_path,
+                alert: "Verify your identity before authorizing an agent."
+  end
+
+  def agent_params
+    params.require(:agent).permit(
+      :name,
+      :spend_limit_amount_cents,
+      :spend_limit_currency,
+      :spend_limit_period,
+      :per_transaction_max_cents,
+      :max_idle_duration_iso8601,
+      :confirmation_threshold_cents,
+      :confirmation_mode,
+      authorized_currencies: [],
+    )
+  end
+
+  # Real implementation would generate a JWK keypair (likely client-side or in
+  # a secure enclave) and derive the DID from it. Stubbed here.
+  def generate_did
+    "did:jwk:#{SecureRandom.urlsafe_base64(32)}"
+  end
+end

--- a/app/controllers/identity_verifications_controller.rb
+++ b/app/controllers/identity_verifications_controller.rb
@@ -17,6 +17,14 @@ class IdentityVerificationsController < ApplicationController
       render :new, status: :unprocessable_entity and return
     end
 
+    # Beltic schema constraint: if id_document_type is set, id_document_country
+    # must also be set, and trust_level must be idv_verified (or higher). Enforce
+    # client-side so the user sees a clear error before we POST to Beltic.
+    if params[:id_document_type].present? && params[:id_document_country].blank?
+      flash[:error] = "Provide the ID document's issuing country when selecting a document type."
+      render :new, status: :unprocessable_entity and return
+    end
+
     Beltic::IssueCredentialJob.perform_later(
       kind:    :user,
       user_id: current_user.id,
@@ -58,7 +66,7 @@ class IdentityVerificationsController < ApplicationController
       date_of_birth:        params[:date_of_birth],
       id_document_type:     params[:id_document_type].presence,
       id_document_country:  params[:id_document_country].presence,
-      parent_business_id:   Houston::Beltic.config.org_credential_id,
+      parent_business_id:   Houston::Beltic.config.org_subject_id,
     }.compact
   end
 

--- a/app/controllers/identity_verifications_controller.rb
+++ b/app/controllers/identity_verifications_controller.rb
@@ -1,0 +1,53 @@
+class IdentityVerificationsController < ApplicationController
+  before_action :authenticate_user!
+
+  # GET /identity_verification/new
+  # Renders the self-attestation modal (Figma: "Verify Your Identity").
+  def new
+    @existing = current_user.beltic_user_credential
+  end
+
+  # POST /identity_verification
+  # Creates a pending VC row and enqueues an async issuance job.
+  # Beltic enforces `self_attestation_complete: true` server-side; we only
+  # set it to true after the user has actually checked the consent boxes.
+  def create
+    unless attestation_complete?
+      flash[:error] = "Please confirm all declarations before submitting."
+      render :new, status: :unprocessable_entity and return
+    end
+
+    Beltic::IssueCredentialJob.perform_later(
+      kind:    :user,
+      user_id: current_user.id,
+      claims:  user_claims_from_params,
+    )
+
+    redirect_to settings_identity_path,
+                notice: "Submitted — Beltic is issuing your credential. You'll see it here in a moment."
+  end
+
+  private
+
+  def attestation_complete?
+    %w[confirm_accuracy consent_issuance understand_revocation].all? do |key|
+      ActiveModel::Type::Boolean.new.cast(params.dig(:declarations, key))
+    end
+  end
+
+  def user_claims_from_params
+    {
+      kyc_status:           "approved",
+      trust_level:          determine_trust_level,
+      nationality:          params[:nationality],
+      date_of_birth:        params[:date_of_birth],
+      id_document_type:     params[:id_document_type].presence,
+      id_document_country:  params[:id_document_country].presence,
+      parent_business_id:   Houston::Beltic.config.org_credential_id,
+    }.compact
+  end
+
+  def determine_trust_level
+    params[:id_document_type].present? ? "idv_verified" : "self_attested"
+  end
+end

--- a/app/controllers/identity_verifications_controller.rb
+++ b/app/controllers/identity_verifications_controller.rb
@@ -27,6 +27,21 @@ class IdentityVerificationsController < ApplicationController
                 notice: "Submitted — Beltic is issuing your credential. You'll see it here in a moment."
   end
 
+  # DELETE /identity/verify
+  # Revokes the user's active Beltic credential. Cascades: all of the user's
+  # agent_authorization credentials become unusable (their delegated_by_subject_id
+  # points at a revoked credential) — Houston's verifier denies them.
+  def destroy
+    cred = current_user.beltic_user_credential
+    if cred&.active?
+      Houston::Beltic.issuer.revoke(cred.credential_id, reason: "revoked_by_user")
+      cred.update!(status: "revoked", revoked_at: Time.current)
+    end
+    current_user.update!(beltic_user_credential: nil, beltic_trust_level: nil)
+
+    redirect_to settings_identity_path, notice: "Identity credential revoked."
+  end
+
   private
 
   def attestation_complete?

--- a/app/controllers/settings/agents_controller.rb
+++ b/app/controllers/settings/agents_controller.rb
@@ -1,0 +1,16 @@
+module Settings
+  class AgentsController < ApplicationController
+    before_action :authenticate_user!
+
+    # GET /settings/agents
+    def index
+      @agents = current_user.agents.order(:created_at)
+    end
+
+    # GET /settings/agents/:id
+    def show
+      @agent = current_user.agents.find(params[:id])
+      @credential = @agent.authorization_credential
+    end
+  end
+end

--- a/app/controllers/settings/identity_controller.rb
+++ b/app/controllers/settings/identity_controller.rb
@@ -1,0 +1,22 @@
+module Settings
+  class IdentityController < ApplicationController
+    before_action :authenticate_user!
+
+    # GET /settings/identity
+    def show
+      @credential = current_user.beltic_user_credential
+      @trust_level = current_user.beltic_trust_level || "unverified"
+      @evidence = @credential&.evidence_refs || []
+      @recent_events = recent_status_events
+    end
+
+    private
+
+    # Recent webhook-driven status changes for this user's credential.
+    # Returns at most 10 events. Stubbed for now — replace with real audit log
+    # once Webhooks::BelticController persists them.
+    def recent_status_events
+      []
+    end
+  end
+end

--- a/app/controllers/webhooks/beltic_controller.rb
+++ b/app/controllers/webhooks/beltic_controller.rb
@@ -8,7 +8,11 @@ module Webhooks
 
     def create
       verifier = Houston::Beltic::WebhookVerifier.new(Houston::Beltic.config.webhook_secret)
-      verifier.verify!(request.raw_post, request.headers["X-Beltic-Signature"])
+      verifier.verify!(
+        request.raw_post,
+        request.headers[Houston::Beltic::WebhookVerifier::SIGNATURE_HEADER],
+        request.headers[Houston::Beltic::WebhookVerifier::TIMESTAMP_HEADER],
+      )
 
       event = JSON.parse(request.raw_post)
       apply_event(event)
@@ -22,25 +26,28 @@ module Webhooks
 
     private
 
+    # Beltic webhook event shape (see Beltic platform: shared/audit-events.ts):
+    #   { id, event_type, credential_id, credential_type, subject_type,
+    #     outcome, outcome_reason, timestamp, intervention_required, ... }
     def apply_event(event)
-      credential_id = event.dig("data", "credential_id")
+      credential_id = event["credential_id"]
       return unless credential_id
 
       vc = VerifiableCredential.find_by(credential_id: credential_id)
       return unless vc
 
-      case event["type"]
-      when "credential.revoked"
+      case event["event_type"]
+      when "credential.revoked", "credential.deleted"
         vc.update!(status: "revoked", revoked_at: Time.current)
       when "credential.suspended"
         vc.update!(status: "suspended")
-      when "credential.issued"
+      when "credential.issued", "credential.reactivated"
         vc.update!(status: "active")
       end
 
       Houston.observer.fire("beltic.credential_status_changed",
                             credential: vc,
-                            event_type: event["type"])
+                            event_type: event["event_type"])
     end
   end
 end

--- a/app/controllers/webhooks/beltic_controller.rb
+++ b/app/controllers/webhooks/beltic_controller.rb
@@ -1,0 +1,46 @@
+module Webhooks
+  class BelticController < ActionController::Base
+    # Beltic webhook receiver. Verifies HMAC, updates the relevant VC row,
+    # fires a Houston observer event for downstream subscribers.
+    #
+    # Events handled: credential.issued | credential.revoked | credential.suspended
+    skip_forgery_protection
+
+    def create
+      verifier = Houston::Beltic::WebhookVerifier.new(Houston::Beltic.config.webhook_secret)
+      verifier.verify!(request.raw_post, request.headers["X-Beltic-Signature"])
+
+      event = JSON.parse(request.raw_post)
+      apply_event(event)
+
+      head :ok
+    rescue Houston::Beltic::WebhookSignatureError
+      head :unauthorized
+    rescue JSON::ParserError
+      head :bad_request
+    end
+
+    private
+
+    def apply_event(event)
+      credential_id = event.dig("data", "credential_id")
+      return unless credential_id
+
+      vc = VerifiableCredential.find_by(credential_id: credential_id)
+      return unless vc
+
+      case event["type"]
+      when "credential.revoked"
+        vc.update!(status: "revoked", revoked_at: Time.current)
+      when "credential.suspended"
+        vc.update!(status: "suspended")
+      when "credential.issued"
+        vc.update!(status: "active")
+      end
+
+      Houston.observer.fire("beltic.credential_status_changed",
+                            credential: vc,
+                            event_type: event["type"])
+    end
+  end
+end

--- a/app/jobs/beltic/issue_credential_job.rb
+++ b/app/jobs/beltic/issue_credential_job.rb
@@ -26,7 +26,7 @@ module Beltic
       user = User.find(user_id)
       subject = {
         type:       "person",
-        id:         "usr_#{user.id}",
+        id:         beltic_user_subject_id(user),
         email:      user.email,
         first_name: user.first_name,
         last_name:  user.last_name,
@@ -37,23 +37,25 @@ module Beltic
 
     def issue_agent_authorization(agent_id)
       agent = Agent.find(agent_id)
-      user_cred = agent.user.beltic_user_credential
-      raise "User #{agent.user.id} has no active Beltic credential" unless user_cred&.active?
+      user = agent.user
+      user_cred = user.beltic_user_credential
+      raise "User #{user.id} has no active Beltic credential" unless user_cred&.active?
 
+      user_subject_id = beltic_user_subject_id(user)
       subject = {
         type:                 "agent",
         id:                   agent.did,
         agent_external_id:    "agent_#{agent.id}",
-        parent_user_id:       user_cred.credential_id,
-        parent_business_id:   Houston::Beltic.config.org_credential_id,
+        parent_user_id:       user_subject_id,
+        parent_business_id:   Houston::Beltic.config.org_subject_id,
       }
-      claims = build_agent_claims(agent, user_cred)
+      claims = build_agent_claims(agent, user_subject_id)
       response = Houston::Beltic.issuer.issue_agent_authorization(subject: subject, claims: claims)
       persist!(response, subject_type: "Agent", subject_id: agent.id,
                          delegated_by_credential_id: user_cred.id)
     end
 
-    def build_agent_claims(agent, user_cred)
+    def build_agent_claims(agent, user_subject_id)
       {
         permissions: [{
           resource_type: "wallet",
@@ -63,7 +65,7 @@ module Beltic
             { operator: "lte", field: "transaction_amount", value: agent.per_transaction_max_cents }
           ],
         }],
-        delegated_by_subject_id: user_cred.credential_id,
+        delegated_by_subject_id: user_subject_id,
         spend_limit: {
           amount:   agent.spend_limit_amount_cents,
           currency: agent.spend_limit_currency,
@@ -73,6 +75,13 @@ module Beltic
         max_idle_duration:     agent.max_idle_duration_iso8601,
         human_present:         agent.confirmation_mode != "never",
       }
+    end
+
+    # Houston's convention for Beltic subject.id of a user. Stable across the
+    # user's lifetime; outlives any single credential. Beltic's schema accepts
+    # any string here — Houston standardizes on this prefix.
+    def beltic_user_subject_id(user)
+      "usr_#{user.id}"
     end
 
     def persist!(response, subject_type:, subject_id:, delegated_by_credential_id: nil)

--- a/app/jobs/beltic/issue_credential_job.rb
+++ b/app/jobs/beltic/issue_credential_job.rb
@@ -1,0 +1,95 @@
+module Beltic
+  # Async wrapper around Houston::Beltic::Issuer. Retries with backoff on
+  # transport/server errors. Does NOT retry on schema or attestation errors —
+  # those are programmer/user errors that won't fix themselves.
+  class IssueCredentialJob < ActiveJob::Base
+    queue_as :default
+
+    retry_on Houston::Beltic::TransportError, wait: :exponentially_longer, attempts: 5
+    retry_on Houston::Beltic::ServerError,    wait: :exponentially_longer, attempts: 5
+    discard_on Houston::Beltic::SelfAttestationIncompleteError
+    discard_on Houston::Beltic::SchemaValidationError
+    discard_on Houston::Beltic::DelegationMissingError
+
+    def perform(kind:, user_id: nil, agent_id: nil, claims: nil)
+      case kind.to_sym
+      when :user                  then issue_user(user_id, claims)
+      when :agent_authorization   then issue_agent_authorization(agent_id)
+      else
+        raise ArgumentError, "Unknown credential kind: #{kind.inspect}"
+      end
+    end
+
+    private
+
+    def issue_user(user_id, claims)
+      user = User.find(user_id)
+      subject = {
+        type:       "person",
+        id:         "usr_#{user.id}",
+        email:      user.email,
+        first_name: user.first_name,
+        last_name:  user.last_name,
+      }
+      response = Houston::Beltic.issuer.issue_user(subject: subject, claims: claims)
+      persist!(response, subject_type: "User", subject_id: user.id)
+    end
+
+    def issue_agent_authorization(agent_id)
+      agent = Agent.find(agent_id)
+      user_cred = agent.user.beltic_user_credential
+      raise "User #{agent.user.id} has no active Beltic credential" unless user_cred&.active?
+
+      subject = {
+        type:                 "agent",
+        id:                   agent.did,
+        agent_external_id:    "agent_#{agent.id}",
+        parent_user_id:       user_cred.credential_id,
+        parent_business_id:   Houston::Beltic.config.org_credential_id,
+      }
+      claims = build_agent_claims(agent, user_cred)
+      response = Houston::Beltic.issuer.issue_agent_authorization(subject: subject, claims: claims)
+      persist!(response, subject_type: "Agent", subject_id: agent.id,
+                         delegated_by_credential_id: user_cred.id)
+    end
+
+    def build_agent_claims(agent, user_cred)
+      {
+        permissions: [{
+          resource_type: "wallet",
+          resource_id:   "*",
+          actions:       %w[checkout payment_authorize],
+          conditions: [
+            { operator: "lte", field: "transaction_amount", value: agent.per_transaction_max_cents }
+          ],
+        }],
+        delegated_by_subject_id: user_cred.credential_id,
+        spend_limit: {
+          amount:   agent.spend_limit_amount_cents,
+          currency: agent.spend_limit_currency,
+          period:   agent.spend_limit_period,
+        },
+        authorized_currencies: agent.authorized_currencies,
+        max_idle_duration:     agent.max_idle_duration_iso8601,
+        human_present:         agent.confirmation_mode != "never",
+      }
+    end
+
+    def persist!(response, subject_type:, subject_id:, delegated_by_credential_id: nil)
+      VerifiableCredential.create!(
+        credential_id:               response["credential_id"] || response["id"],
+        credential_type:             response["credential_type"],
+        subject_type:                subject_type,
+        subject_id:                  subject_id,
+        status:                      response["status"] || "active",
+        signed_payload:              response["signed_payload"],
+        claims:                      response["claims"] || {},
+        evidence_refs:               response["evidence_refs"] || [],
+        delegated_by_credential_id:  delegated_by_credential_id,
+        issued_at:                   response["issued_at"],
+        expires_at:                  response["expires_at"],
+        raw_response:                response,
+      )
+    end
+  end
+end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,0 +1,26 @@
+class Agent < ActiveRecord::Base
+  STATUSES = %w[active paused revoked].freeze
+  CONFIRMATION_MODES = %w[always threshold never].freeze
+  SPEND_PERIODS = %w[per_transaction daily weekly monthly lifetime].freeze
+
+  belongs_to :user
+  has_many :verifiable_credentials, as: :subject, dependent: :destroy
+
+  validates :name,              presence: true
+  validates :did,               presence: true, uniqueness: true,
+                                format: { with: /\Adid:jwk:/, message: "must be a did:jwk identifier" }
+  validates :status,            inclusion: { in: STATUSES }
+  validates :confirmation_mode, inclusion: { in: CONFIRMATION_MODES }
+  validates :spend_limit_period, inclusion: { in: SPEND_PERIODS, allow_nil: true }
+
+  scope :active, -> { where(status: "active") }
+
+  # The current authorization credential (most recent active agent_authorization).
+  def authorization_credential
+    verifiable_credentials.active.for_type("agent_authorization").order(issued_at: :desc).first
+  end
+
+  def authorized?
+    authorization_credential.present?
+  end
+end

--- a/app/models/verifiable_credential.rb
+++ b/app/models/verifiable_credential.rb
@@ -1,0 +1,33 @@
+class VerifiableCredential < ActiveRecord::Base
+  TYPES = %w[business user agent_authorization outcome_attestation].freeze
+  STATUSES = %w[active suspended revoked expired].freeze
+
+  belongs_to :subject,                polymorphic: true
+  belongs_to :delegated_by_credential, class_name: "VerifiableCredential", optional: true
+
+  has_many :delegated_credentials,
+           class_name:  "VerifiableCredential",
+           foreign_key: :delegated_by_credential_id
+
+  validates :credential_id,   presence: true, uniqueness: true
+  validates :credential_type, inclusion: { in: TYPES }
+  validates :status,          inclusion: { in: STATUSES }
+
+  scope :active,   -> { where(status: "active") }
+  scope :expired,  -> { where("expires_at < ?", Time.current) }
+  scope :for_type, ->(type) { where(credential_type: type) }
+
+  def active?
+    status == "active" && (expires_at.nil? || expires_at.future?)
+  end
+
+  def revoked?
+    status == "revoked"
+  end
+
+  # Truncated credential ID for UI display ("cred_a8f3...d92b1c").
+  def short_id
+    return credential_id if credential_id.length <= 18
+    "#{credential_id[0, 9]}…#{credential_id[-6, 6]}"
+  end
+end

--- a/app/models/verifiable_credential.rb
+++ b/app/models/verifiable_credential.rb
@@ -2,6 +2,11 @@ class VerifiableCredential < ActiveRecord::Base
   TYPES = %w[business user agent_authorization outcome_attestation].freeze
   STATUSES = %w[active suspended revoked expired].freeze
 
+  # signed_payload is the raw JWT-VC. Encrypted at rest because anyone holding it
+  # can present it as proof of identity until revoked. Requires LOCKBOX_MASTER_KEY
+  # (generate with: bundle exec rake "lockbox:generate_key").
+  has_encrypted :signed_payload if respond_to?(:has_encrypted)
+
   belongs_to :subject,                polymorphic: true
   belongs_to :delegated_by_credential, class_name: "VerifiableCredential", optional: true
 

--- a/app/views/agent_authorizations/new.html.erb
+++ b/app/views/agent_authorizations/new.html.erb
@@ -1,0 +1,116 @@
+<% title "Authorize agent" %>
+
+<h1 class="project-banner space-below">
+  Authorize <%= @agent.name.presence || "this agent" %>
+  <small>Set the spending limits Beltic will encode into the credential</small>
+</h1>
+
+<% if @user_credential.present? %>
+  <div class="alert alert-info">
+    <strong>Linked to your verified Beltic identity.</strong>
+    Trust level: <%= @user_credential.claims["trust_level"] %> · expires
+    <%= @user_credential.expires_at&.to_s(:long) %>
+  </div>
+<% end %>
+
+<%
+  # New agent: POST /agents (AgentsController#create).
+  # Re-authorize existing: POST /agents/:agent_id/authorization (AgentAuthorizationsController#create).
+  form_url    = @agent.persisted? ? agent_authorization_path(agent_id: @agent.id) : agents_path
+  form_method = :post
+%>
+<%= form_with model: @agent,
+              url:   form_url,
+              method: form_method,
+              scope: :agent,
+              class: "form-horizontal",
+              local: true do |f| %>
+
+  <fieldset>
+    <legend>Agent</legend>
+
+    <div class="control-group">
+      <%= f.label :name, class: "control-label" %>
+      <div class="controls"><%= f.text_field :name, required: true %></div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Spending limits</legend>
+    <p><small>These map to <code>claims.spend_limit</code> and <code>claims.authorized_currencies</code> on the Beltic credential.</small></p>
+
+    <div class="control-group">
+      <%= f.label :spend_limit_amount_cents, "Daily limit (cents)", class: "control-label" %>
+      <div class="controls">
+        <%= f.number_field :spend_limit_amount_cents, min: 0, step: 1, value: 25000 %>
+        <%= f.select :spend_limit_currency, %w[USD BRL EUR GBP CAD], { selected: "USD" }, class: "input-small" %>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <%= f.label :per_transaction_max_cents, "Per-transaction max (cents)", class: "control-label" %>
+      <div class="controls">
+        <%= f.number_field :per_transaction_max_cents, min: 0, step: 1, value: 10000 %>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <%= f.label :spend_limit_period, class: "control-label" %>
+      <div class="controls">
+        <%= f.select :spend_limit_period, Agent::SPEND_PERIODS.map { |p| [p.humanize, p] }, selected: "daily" %>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <%= f.label :authorized_currencies, class: "control-label" %>
+      <div class="controls">
+        <%= f.collection_check_boxes :authorized_currencies, %w[USD BRL EUR GBP CAD], :to_s, :to_s do |b| %>
+          <label class="checkbox inline"><%= b.check_box %> <%= b.text %></label>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <%= f.label :max_idle_duration_iso8601, "Auto-pause if idle (ISO-8601)", class: "control-label" %>
+      <div class="controls"><%= f.text_field :max_idle_duration_iso8601, value: "PT4H", placeholder: "e.g. PT4H, P1D" %></div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Confirm before purchase</legend>
+
+    <% [
+      ["always",    "Always confirm with me",        "Best for a new agent you don't trust yet."],
+      ["threshold", "Only purchases above a threshold", "Recommended — agent runs autonomously under the limit, asks above it."],
+      ["never",     "Never (full autonomy)",         "Agent can spend up to your daily limit without asking. Higher-risk."],
+    ].each do |mode, label, helper| %>
+      <div class="control-group">
+        <div class="controls">
+          <label class="radio">
+            <%= f.radio_button :confirmation_mode, mode, checked: (mode == "threshold") %>
+            <strong><%= label %></strong>
+            <p class="help-block"><small><%= helper %></small></p>
+          </label>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="control-group">
+      <%= f.label :confirmation_threshold_cents, "Threshold (cents)", class: "control-label" %>
+      <div class="controls"><%= f.number_field :confirmation_threshold_cents, value: 5000, min: 0 %></div>
+    </div>
+  </fieldset>
+
+  <div class="alert alert-info">
+    <strong>What gets sent to Beltic:</strong>
+    Beltic mints an <code>agent_authorization</code> credential containing the agent's DID,
+    your user credential ID as <code>delegated_by_subject_id</code>, the spend limits and
+    currencies above, and the actions the agent is permitted. The credential is revoked
+    instantly when you remove the agent.
+  </div>
+
+  <div class="form-actions">
+    <%= f.submit "Authorize agent", class: "btn btn-primary" %>
+    <%= link_to "Cancel", :back, class: "btn" %>
+  </div>
+<% end %>

--- a/app/views/identity_verifications/new.html.erb
+++ b/app/views/identity_verifications/new.html.erb
@@ -1,0 +1,99 @@
+<% title "Verify Your Identity" %>
+
+<h1 class="project-banner space-below">
+  Verify Your Identity
+  <small>Issue your Beltic identity credential</small>
+</h1>
+
+<%= form_with url: identity_verification_path, method: :post, class: "form-horizontal", local: true do |f| %>
+
+  <p>
+    Houston uses Beltic to issue you a verifiable identity credential. Review the
+    information below and complete the required fields. Beltic stores only what's
+    needed to issue your credential.
+  </p>
+
+  <fieldset>
+    <legend>Information from your account</legend>
+    <p><small>Pulled from your Houston profile — read only</small></p>
+
+    <div class="control-group">
+      <label class="control-label">Full name</label>
+      <div class="controls"><span class="uneditable-input"><%= current_user.full_name %></span></div>
+    </div>
+
+    <div class="control-group">
+      <label class="control-label">Email</label>
+      <div class="controls"><span class="uneditable-input"><%= current_user.email %></span></div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Required attestations</legend>
+
+    <div class="control-group">
+      <label class="control-label" for="nationality">Nationality <span class="text-error">*</span></label>
+      <div class="controls">
+        <%= select_tag :nationality,
+            options_for_select([["Select country", ""]] + country_options),
+            class: "input-large", required: true %>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <label class="control-label" for="date_of_birth">Date of birth <span class="text-error">*</span></label>
+      <div class="controls">
+        <%= date_field_tag :date_of_birth, nil, required: true %>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <label class="control-label optional" for="id_document_type">Government ID type</label>
+      <div class="controls">
+        <%= select_tag :id_document_type, options_for_select([
+              ["None", ""],
+              ["Passport", "passport"],
+              ["Driver's License", "drivers_license"],
+              ["National ID", "national_id"],
+              ["Residence Permit", "residence_permit"],
+            ]), class: "input-large" %>
+        <p class="help-block"><small>Strongly recommended — unlocks idv_verified trust level</small></p>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <label class="control-label optional" for="id_document_country">ID document country</label>
+      <div class="controls">
+        <%= select_tag :id_document_country,
+            options_for_select([["Required if document type selected", ""]] + country_options),
+            class: "input-large" %>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Declarations</legend>
+
+    <% [
+      ["confirm_accuracy",     "I confirm the information above is accurate and current."],
+      ["consent_issuance",     "I consent to Beltic issuing a Verifiable Credential based on this information."],
+      ["understand_revocation","I understand this credential may be revoked if found inaccurate."],
+    ].each do |key, label| %>
+      <div class="control-group">
+        <div class="controls">
+          <label class="checkbox">
+            <%= check_box_tag "declarations[#{key}]", "1", false, required: true %>
+            <%= label %>
+          </label>
+        </div>
+      </div>
+    <% end %>
+  </fieldset>
+
+  <p><small>Your credential will be valid for 1 year. It can be revoked at any time from your profile settings.</small></p>
+
+  <div class="form-actions">
+    <%= submit_tag "Issue Credential", class: "btn btn-primary" %>
+    <%= link_to "Cancel", :back, class: "btn" %>
+  </div>
+<% end %>

--- a/app/views/settings/agents/index.html.erb
+++ b/app/views/settings/agents/index.html.erb
@@ -1,0 +1,62 @@
+<% title "Agents" %>
+
+<h1 class="project-banner space-below">
+  Agents
+  <small>Agents you've authorized to act on your behalf</small>
+</h1>
+
+<% if @agents.any? %>
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Agent</th>
+        <th>Status</th>
+        <th>Daily limit</th>
+        <th>Confirmation</th>
+        <th>Credential</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @agents.each do |agent| %>
+        <tr>
+          <td><%= link_to agent.name, settings_agent_path(agent) %></td>
+          <td>
+            <span class="label <%= agent.status == "active" ? "label-success" : "" %>">
+              <%= agent.status %>
+            </span>
+          </td>
+          <td>
+            <% if agent.spend_limit_amount_cents %>
+              $<%= "%.2f" % (agent.spend_limit_amount_cents.to_f / 100) %>
+              <%= agent.spend_limit_currency %> / <%= agent.spend_limit_period %>
+            <% else %>—<% end %>
+          </td>
+          <td><%= agent.confirmation_mode %></td>
+          <td>
+            <% if (vc = agent.authorization_credential) %>
+              <code><%= vc.short_id %></code>
+            <% else %>
+              <em>none</em>
+            <% end %>
+          </td>
+          <td>
+            <% if agent.authorized? %>
+              <%= button_to "Revoke", agent_authorization_path(agent_id: agent.id), method: :delete,
+                  class: "btn btn-small btn-danger",
+                  data: { confirm: "Revoke #{agent.name}? Beltic will mark its credential revoked immediately." } %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alert">
+    <p>You haven't authorized any agents yet.</p>
+  </div>
+<% end %>
+
+<p>
+  <%= link_to "+ Authorize new agent", new_agent_path, class: "btn btn-primary" %>
+</p>

--- a/app/views/settings/agents/show.html.erb
+++ b/app/views/settings/agents/show.html.erb
@@ -1,0 +1,42 @@
+<% title @agent.name %>
+
+<h1 class="project-banner space-below">
+  <%= @agent.name %>
+  <small>did:jwk — <%= @agent.did %></small>
+</h1>
+
+<dl class="dl-horizontal">
+  <dt>Status</dt><dd><%= @agent.status %></dd>
+  <dt>Confirmation</dt><dd><%= @agent.confirmation_mode %></dd>
+  <dt>Daily limit</dt>
+  <dd>
+    <% if @agent.spend_limit_amount_cents %>
+      $<%= "%.2f" % (@agent.spend_limit_amount_cents.to_f / 100) %>
+      <%= @agent.spend_limit_currency %> / <%= @agent.spend_limit_period %>
+    <% else %>—<% end %>
+  </dd>
+  <dt>Per-transaction max</dt>
+  <dd>
+    <% if @agent.per_transaction_max_cents %>
+      $<%= "%.2f" % (@agent.per_transaction_max_cents.to_f / 100) %>
+    <% else %>—<% end %>
+  </dd>
+  <dt>Currencies</dt><dd><%= Array(@agent.authorized_currencies).join(", ") %></dd>
+  <dt>Idle timeout</dt><dd><%= @agent.max_idle_duration_iso8601 %></dd>
+  <% if @credential %>
+    <dt>Credential</dt>
+    <dd>
+      <code><%= @credential.short_id %></code>,
+      issued <%= @credential.issued_at&.to_s(:long) %>,
+      expires <%= @credential.expires_at&.to_s(:long) %>
+    </dd>
+  <% end %>
+</dl>
+
+<%= link_to "Re-authorize (update limits)", new_agent_authorization_path(agent_id: @agent.id), class: "btn" %>
+
+<% if @agent.authorized? %>
+  <%= button_to "Revoke credential", agent_authorization_path(agent_id: @agent.id), method: :delete,
+      class: "btn btn-danger",
+      data: { confirm: "Revoke #{@agent.name}? Beltic will mark its credential revoked immediately." } %>
+<% end %>

--- a/app/views/settings/identity/show.html.erb
+++ b/app/views/settings/identity/show.html.erb
@@ -1,0 +1,59 @@
+<% title "Identity" %>
+
+<h1 class="project-banner space-below">
+  Identity
+  <small>Your Beltic-issued credential, plus options to strengthen it</small>
+</h1>
+
+<% if @credential&.active? %>
+  <section>
+    <h3>Your identity
+      <span class="label label-success">Verified</span>
+    </h3>
+
+    <dl class="dl-horizontal">
+      <dt>Credential ID</dt>
+      <dd><code><%= @credential.short_id %></code></dd>
+
+      <dt>Trust level</dt>
+      <dd><%= @trust_level %></dd>
+
+      <dt>Issued</dt>
+      <dd><%= @credential.issued_at&.to_s(:long) %></dd>
+
+      <dt>Expires</dt>
+      <dd><%= @credential.expires_at&.to_s(:long) %></dd>
+    </dl>
+
+    <%= link_to "Re-verify identity", new_identity_verification_path, class: "btn" %>
+    <%= link_to "Strengthen your identity", new_identity_strengthening_path, class: "btn" %>
+  </section>
+
+  <section style="margin-top: 2em;">
+    <h3>Strengthen your identity</h3>
+    <p>Raise your trust level by adding evidence. Each upload re-issues your credential at a higher tier; old ones are revoked atomically.</p>
+    <ul>
+      <% if @trust_level == "idv_verified" %>
+        <li><strong>✓ Government ID verified.</strong> You're at <code>idv_verified</code>.</li>
+      <% else %>
+        <li>Upload a government ID → <code>idv_verified</code> trust level</li>
+      <% end %>
+      <li>Connect external identity (LinkedIn, GitHub) → stacked <code>outcome_attestation</code> credentials</li>
+      <li>Upload supporting evidence (address proof, employer letter) → added to <code>evidence_refs</code></li>
+    </ul>
+  </section>
+
+  <section style="margin-top: 2em;">
+    <h3>Danger zone</h3>
+    <%= button_to "Revoke credential", identity_verification_path, method: :delete,
+        class: "btn btn-danger",
+        data: { confirm: "Revoke your Beltic credential? You'll lose all agent authorizations and must re-verify before issuing new ones." } %>
+  </section>
+
+<% else %>
+  <div class="alert">
+    <h3>Identity not verified</h3>
+    <p>Verify your identity to unlock agent authorization and other features that need a portable, verifiable identity.</p>
+    <%= link_to "Verify identity", new_identity_verification_path, class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,10 @@
+# Local-dev Rack entrypoint for running the houston-core gem source as a Rails
+# app. Distributed Houston instances have their own config.ru via the template
+# in templates/new-instance/; this file lets us boot the gem repo directly.
+
+$HOUSTON_PROCESS_TYPE = :web_server
+
+require_relative "config/application"
+require_relative "config/environment"
+
+run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,10 @@ require "rack/utf8_sanitizer"
 require "kramdown"
 require "slackdown"
 
+# Beltic verifiable-credentials integration
+require "jwt"
+require "lockbox"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,14 +2,16 @@ development:
   adapter: postgresql
   encoding: utf8
   database: houston_core_development
-  host: localhost
+  host: <%= ENV.fetch("HOUSTON_DB_HOST", "localhost") %>
+  port: <%= ENV.fetch("HOUSTON_DB_PORT", 5432) %>
   prepared_statements: false
 
 test:
   adapter: postgresql
   encoding: utf8
   database: houston_core_test
-  host: localhost
+  host: <%= ENV.fetch("HOUSTON_DB_HOST", "localhost") %>
+  port: <%= ENV.fetch("HOUSTON_DB_PORT", 5432) %>
   prepared_statements: false
 
 # Just so we can precompile assets locally
@@ -17,5 +19,6 @@ production:
   adapter: postgresql
   encoding: utf8
   database: houston_core_development
-  host: localhost
+  host: <%= ENV.fetch("HOUSTON_DB_HOST", "localhost") %>
+  port: <%= ENV.fetch("HOUSTON_DB_PORT", 5432) %>
   prepared_statements: false

--- a/config/initializers/aes_cbc_cookies.rb
+++ b/config/initializers/aes_cbc_cookies.rb
@@ -1,0 +1,14 @@
+# Workaround for OpenSSL 3 / Ruby 2.6 incompatibility with Rails 6's AES-256-GCM
+# encrypted cookies. Hitting any cookie-encrypting code path (e.g. Devise's
+# warden session storage) throws OpenSSL::Cipher::CipherError "couldn't set
+# additional authenticated data" because Ruby's bundled OpenSSL bindings refuse
+# to set AAD on a freshly-initialized cipher. Reverting to AES-256-CBC (the
+# pre-Rails-5.2 default) sidesteps AEAD entirely.
+#
+# Safe for local development. For production, upgrade Ruby (2.7+ ships with
+# OpenSSL 1.1 bindings that work, or 3.1+ has fixed AEAD) rather than carrying
+# this override.
+
+Rails.application.config.action_dispatch.use_authenticated_message_encryption = false
+Rails.application.config.action_dispatch.encrypted_cookie_cipher = "aes-256-cbc"
+Rails.application.config.active_support.use_authenticated_message_encryption = false

--- a/config/initializers/beltic.rb
+++ b/config/initializers/beltic.rb
@@ -1,0 +1,12 @@
+require "houston/beltic"
+
+Houston::Beltic.configure do |b|
+  b.api_key           = ENV["BELTIC_API_KEY"]
+  b.base_url          = ENV["BELTIC_BASE_URL"] || "https://api.beltic.com/v1"
+  b.webhook_secret    = ENV["BELTIC_WEBHOOK_SECRET"]
+  b.org_credential_id = ENV["BELTIC_ORG_CREDENTIAL_ID"]
+end
+
+if Rails.env.production? && !Houston::Beltic.config.configured?
+  Rails.logger.warn("[Beltic] BELTIC_API_KEY is not set — VC issuance will be disabled")
+end

--- a/config/initializers/beltic.rb
+++ b/config/initializers/beltic.rb
@@ -5,6 +5,7 @@ Houston::Beltic.configure do |b|
   b.base_url          = ENV["BELTIC_BASE_URL"] || "https://api.beltic.com/v1"
   b.webhook_secret    = ENV["BELTIC_WEBHOOK_SECRET"]
   b.org_credential_id = ENV["BELTIC_ORG_CREDENTIAL_ID"]
+  b.org_subject_id    = ENV["BELTIC_ORG_SUBJECT_ID"]
 end
 
 if Rails.env.production? && !Houston::Beltic.config.configured?

--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -1,0 +1,10 @@
+return unless defined?(Lockbox)
+
+# Master key for at-rest encryption of secrets (e.g. VerifiableCredential#signed_payload).
+# Generate with:  bundle exec rake "lockbox:generate_key"
+# Set as ENV LOCKBOX_MASTER_KEY or in Rails encrypted credentials (preferred for prod).
+Lockbox.master_key = ENV["LOCKBOX_MASTER_KEY"] || Rails.application.credentials.dig(:lockbox, :master_key)
+
+if Rails.env.production? && Lockbox.master_key.to_s.empty?
+  Rails.logger.warn("[Lockbox] LOCKBOX_MASTER_KEY is not set — encrypted attributes will fail")
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,27 @@ Rails.application.routes.draw do
 
 
 
+  # Beltic Verifiable Credentials
+  # See docs/integrations/beltic.md
+
+  resource :identity_verification,    only: [:new, :create, :destroy], path: "identity/verify"
+  resource :identity_strengthening,   only: [:new, :create],            path: "identity/strengthen"
+
+  namespace :settings do
+    resource  :identity, only: [:show], controller: "identity"
+    resources :agents,   only: [:index, :show]
+  end
+
+  resources :agents, only: [:new, :create] do
+    resource :authorization, only: [:new, :create, :destroy], controller: "agent_authorizations"
+  end
+
+  namespace :webhooks do
+    resource :beltic, only: [:create], controller: "beltic"
+  end
+
+
+
   # Authorizations
 
   get "authorizations" => "authorizations#index", as: :authorizations

--- a/db/migrate/20260522120000_create_verifiable_credentials.rb
+++ b/db/migrate/20260522120000_create_verifiable_credentials.rb
@@ -1,0 +1,30 @@
+class CreateVerifiableCredentials < ActiveRecord::Migration[6.0]
+  def change
+    create_table :verifiable_credentials do |t|
+      t.string  :credential_id,              null: false
+      t.string  :credential_type,            null: false
+      t.string  :subject_type,               null: false
+      t.bigint  :subject_id,                 null: false
+      t.string  :status,                     null: false, default: "active"
+      t.text    :signed_payload
+      t.jsonb   :claims,                     null: false, default: {}
+      t.jsonb   :evidence_refs,              null: false, default: []
+      t.bigint  :delegated_by_credential_id
+      t.datetime :issued_at
+      t.datetime :expires_at
+      t.datetime :revoked_at
+      t.jsonb   :raw_response,               null: false, default: {}
+      t.timestamps
+    end
+
+    add_index :verifiable_credentials, :credential_id, unique: true
+    add_index :verifiable_credentials, [:subject_type, :subject_id]
+    add_index :verifiable_credentials, :status
+    add_index :verifiable_credentials, :expires_at,
+              where: "status = 'active'",
+              name:  "idx_active_vcs_by_expiry"
+    add_foreign_key :verifiable_credentials,
+                    :verifiable_credentials,
+                    column: :delegated_by_credential_id
+  end
+end

--- a/db/migrate/20260522120000_create_verifiable_credentials.rb
+++ b/db/migrate/20260522120000_create_verifiable_credentials.rb
@@ -6,7 +6,7 @@ class CreateVerifiableCredentials < ActiveRecord::Migration[6.0]
       t.string  :subject_type,               null: false
       t.bigint  :subject_id,                 null: false
       t.string  :status,                     null: false, default: "active"
-      t.text    :signed_payload
+      t.text    :signed_payload_ciphertext
       t.jsonb   :claims,                     null: false, default: {}
       t.jsonb   :evidence_refs,              null: false, default: []
       t.bigint  :delegated_by_credential_id

--- a/db/migrate/20260522120001_create_agents.rb
+++ b/db/migrate/20260522120001_create_agents.rb
@@ -1,0 +1,22 @@
+class CreateAgents < ActiveRecord::Migration[6.0]
+  def change
+    create_table :agents do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string  :name,                       null: false
+      t.string  :did,                        null: false
+      t.string  :status,                     null: false, default: "active"
+      t.integer :spend_limit_amount_cents
+      t.string  :spend_limit_currency
+      t.string  :spend_limit_period
+      t.integer :per_transaction_max_cents
+      t.jsonb   :authorized_currencies,      null: false, default: []
+      t.string  :max_idle_duration_iso8601
+      t.integer :confirmation_threshold_cents
+      t.string  :confirmation_mode,          null: false, default: "threshold"
+      t.timestamps
+    end
+
+    add_index :agents, :did, unique: true
+    add_index :agents, [:user_id, :status]
+  end
+end

--- a/db/migrate/20260522120002_add_beltic_fields_to_users.rb
+++ b/db/migrate/20260522120002_add_beltic_fields_to_users.rb
@@ -1,0 +1,9 @@
+class AddBelticFieldsToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :users, :beltic_user_credential,
+                  foreign_key: { to_table: :verifiable_credentials },
+                  null: true
+    add_column :users, :beltic_trust_level, :string
+    add_index  :users, :beltic_trust_level
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,9 +1,7 @@
---
--- PostgreSQL database dump
---
+\restrict xStEcSXgux3eP0jwNaP8rlDwEmiRXKvQBLG6ImoUbgRu3n4ryaK6M8fLNrgHk6K
 
--- Dumped from database version 10.5
--- Dumped by pg_dump version 10.5
+-- Dumped from database version 14.23 (Homebrew)
+-- Dumped by pg_dump version 14.23 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -12,26 +10,13 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: actions; Type: TABLE; Schema: public; Owner: -
@@ -67,6 +52,48 @@ CREATE SEQUENCE public.actions_id_seq
 --
 
 ALTER SEQUENCE public.actions_id_seq OWNED BY public.actions.id;
+
+
+--
+-- Name: agents; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.agents (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    name character varying NOT NULL,
+    did character varying NOT NULL,
+    status character varying DEFAULT 'active'::character varying NOT NULL,
+    spend_limit_amount_cents integer,
+    spend_limit_currency character varying,
+    spend_limit_period character varying,
+    per_transaction_max_cents integer,
+    authorized_currencies jsonb DEFAULT '[]'::jsonb NOT NULL,
+    max_idle_duration_iso8601 character varying,
+    confirmation_threshold_cents integer,
+    confirmation_mode character varying DEFAULT 'threshold'::character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: agents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.agents_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: agents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.agents_id_seq OWNED BY public.agents.id;
 
 
 --
@@ -469,7 +496,9 @@ CREATE TABLE public.users (
     nickname character varying,
     username character varying,
     props jsonb DEFAULT '{}'::jsonb,
-    role character varying DEFAULT 'Member'::character varying
+    role character varying DEFAULT 'Member'::character varying,
+    beltic_user_credential_id bigint,
+    beltic_trust_level character varying
 );
 
 
@@ -490,6 +519,49 @@ CREATE SEQUENCE public.users_id_seq
 --
 
 ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
+
+
+--
+-- Name: verifiable_credentials; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.verifiable_credentials (
+    id bigint NOT NULL,
+    credential_id character varying NOT NULL,
+    credential_type character varying NOT NULL,
+    subject_type character varying NOT NULL,
+    subject_id bigint NOT NULL,
+    status character varying DEFAULT 'active'::character varying NOT NULL,
+    signed_payload_ciphertext text,
+    claims jsonb DEFAULT '{}'::jsonb NOT NULL,
+    evidence_refs jsonb DEFAULT '[]'::jsonb NOT NULL,
+    delegated_by_credential_id bigint,
+    issued_at timestamp without time zone,
+    expires_at timestamp without time zone,
+    revoked_at timestamp without time zone,
+    raw_response jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: verifiable_credentials_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.verifiable_credentials_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: verifiable_credentials_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.verifiable_credentials_id_seq OWNED BY public.verifiable_credentials.id;
 
 
 --
@@ -536,6 +608,13 @@ ALTER SEQUENCE public.versions_id_seq OWNED BY public.versions.id;
 --
 
 ALTER TABLE ONLY public.actions ALTER COLUMN id SET DEFAULT nextval('public.actions_id_seq'::regclass);
+
+
+--
+-- Name: agents id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agents ALTER COLUMN id SET DEFAULT nextval('public.agents_id_seq'::regclass);
 
 
 --
@@ -616,6 +695,13 @@ ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_
 
 
 --
+-- Name: verifiable_credentials id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verifiable_credentials ALTER COLUMN id SET DEFAULT nextval('public.verifiable_credentials_id_seq'::regclass);
+
+
+--
 -- Name: versions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -628,6 +714,14 @@ ALTER TABLE ONLY public.versions ALTER COLUMN id SET DEFAULT nextval('public.ver
 
 ALTER TABLE ONLY public.actions
     ADD CONSTRAINT actions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: agents agents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agents
+    ADD CONSTRAINT agents_pkey PRIMARY KEY (id);
 
 
 --
@@ -735,6 +829,14 @@ ALTER TABLE ONLY public.users
 
 
 --
+-- Name: verifiable_credentials verifiable_credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verifiable_credentials
+    ADD CONSTRAINT verifiable_credentials_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: versions versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -743,10 +845,38 @@ ALTER TABLE ONLY public.versions
 
 
 --
+-- Name: idx_active_vcs_by_expiry; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_active_vcs_by_expiry ON public.verifiable_credentials USING btree (expires_at) WHERE ((status)::text = 'active'::text);
+
+
+--
 -- Name: index_actions_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_actions_on_name ON public.actions USING btree (name);
+
+
+--
+-- Name: index_agents_on_did; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_agents_on_did ON public.agents USING btree (did);
+
+
+--
+-- Name: index_agents_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_agents_on_user_id ON public.agents USING btree (user_id);
+
+
+--
+-- Name: index_agents_on_user_id_and_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_agents_on_user_id_and_status ON public.agents USING btree (user_id, status);
 
 
 --
@@ -855,6 +985,20 @@ CREATE INDEX index_users_on_authentication_token ON public.users USING btree (au
 
 
 --
+-- Name: index_users_on_beltic_trust_level; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_beltic_trust_level ON public.users USING btree (beltic_trust_level);
+
+
+--
+-- Name: index_users_on_beltic_user_credential_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_beltic_user_credential_id ON public.users USING btree (beltic_user_credential_id);
+
+
+--
 -- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -887,6 +1031,27 @@ CREATE INDEX index_users_on_invited_by_id ON public.users USING btree (invited_b
 --
 
 CREATE UNIQUE INDEX index_users_on_reset_password_token ON public.users USING btree (reset_password_token);
+
+
+--
+-- Name: index_verifiable_credentials_on_credential_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_verifiable_credentials_on_credential_id ON public.verifiable_credentials USING btree (credential_id);
+
+
+--
+-- Name: index_verifiable_credentials_on_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_verifiable_credentials_on_status ON public.verifiable_credentials USING btree (status);
+
+
+--
+-- Name: index_verifiable_credentials_on_subject_type_and_subject_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_verifiable_credentials_on_subject_type_and_subject_id ON public.verifiable_credentials USING btree (subject_type, subject_id);
 
 
 --
@@ -956,6 +1121,30 @@ ALTER TABLE ONLY public.follows
 
 
 --
+-- Name: verifiable_credentials fk_rails_da9c5b2388; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verifiable_credentials
+    ADD CONSTRAINT fk_rails_da9c5b2388 FOREIGN KEY (delegated_by_credential_id) REFERENCES public.verifiable_credentials(id);
+
+
+--
+-- Name: users fk_rails_e0b143aec5; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT fk_rails_e0b143aec5 FOREIGN KEY (beltic_user_credential_id) REFERENCES public.verifiable_credentials(id);
+
+
+--
+-- Name: agents fk_rails_ef89880eea; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agents
+    ADD CONSTRAINT fk_rails_ef89880eea FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: api_tokens fk_rails_f16b5e0447; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -966,6 +1155,8 @@ ALTER TABLE ONLY public.api_tokens
 --
 -- PostgreSQL database dump complete
 --
+
+\unrestrict xStEcSXgux3eP0jwNaP8rlDwEmiRXKvQBLG6ImoUbgRu3n4ryaK6M8fLNrgHk6K
 
 SET search_path TO "$user", public;
 
@@ -1075,6 +1266,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170307035755'),
 ('20170310024505'),
 ('20170329030329'),
-('20181102202848');
+('20181102202848'),
+('20260522120000'),
+('20260522120001'),
+('20260522120002');
 
 

--- a/docs/integrations/beltic-local-dev.md
+++ b/docs/integrations/beltic-local-dev.md
@@ -1,0 +1,205 @@
+# Local Development — Houston ↔ Beltic
+
+End-to-end setup for running Houston + Beltic locally and walking the integration
+flow against a real Beltic API instance (not a mock).
+
+## Prereqs
+
+- Ruby 2.6.10 (Houston's pinned version — check `ruby --version`)
+- Bundler (`gem install bundler`)
+- PostgreSQL 9.4+ (`brew install postgresql@14 && brew services start postgresql@14`)
+- pnpm + Node 22 (for Beltic platform)
+- Docker + Docker Compose (for Beltic's MongoDB / LocalStack / nginx)
+- `ngrok` (only if you want Beltic to deliver webhooks to your local Houston)
+- `gh` CLI (already installed)
+
+## 1. Start Beltic locally
+
+In one terminal, in the Beltic platform repo:
+
+```bash
+cd ~/Documents/Work/Beltic/platform
+
+# First time only:
+pnpm install
+pnpm build
+make env-local-sync          # pulls local env from 1Password — auth first
+
+# Every session:
+make dev-up                  # starts MongoDB + LocalStack + nginx
+pnpm aws:terraform:local     # bootstraps local AWS resources (KMS, DynamoDB, S3)
+pnpm dev                     # esbuild watchers + lambda log streamer
+```
+
+When ready, the Credentials API will be reachable at **http://localhost:8080/v1**.
+
+Sanity check it's alive:
+
+```bash
+curl -s http://localhost:8080/.well-known/jwks.json | jq .keys[0].kid
+```
+
+## 2. Create a Beltic API key for Houston
+
+The Beltic Console UI (`http://localhost:3000` once running) lets you create API
+keys against a WorkOS organization. For local dev:
+
+1. Sign into the Console with your WorkOS test account.
+2. Switch to a sandbox organization (or create one).
+3. Settings → API keys → Create key.
+4. Grant scopes: `credentials:write`, `credentials:read`, `credentials:revoke`, `credentials:verify`.
+5. Copy the `sk_staging_…` value — Beltic won't show it again.
+
+(If the Console isn't running, see Beltic's own README for the seed-script path
+to insert an API key directly into the local DynamoDB table.)
+
+## 3. Set up Houston
+
+In another terminal, in the Houston repo:
+
+```bash
+cd ~/Documents/Work/Houston/houston-core
+
+# First time only:
+gem install bundler --conservative
+bundle install
+bin/setup                    # creates DB, runs db:prepare
+
+# Generate a Lockbox master key for encrypting signed_payload at rest
+bundle exec rake lockbox:generate_key  # prints the key
+
+# Create the .env from the template
+cp .env.example .env         # then edit .env (see below)
+```
+
+Edit `.env` with at least:
+
+```bash
+BELTIC_API_KEY=sk_staging_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+BELTIC_BASE_URL=http://localhost:8080/v1
+LOCKBOX_MASTER_KEY=<the key from lockbox:generate_key>
+
+# Webhook subscription comes later (step 6)
+```
+
+Run the new migrations:
+
+```bash
+bin/rails db:migrate
+```
+
+## 4. Bootstrap Houston's business credential
+
+```bash
+HOUSTON_ORG_NAME="Houston Software Inc." \
+HOUSTON_ORG_REGISTRATION="EIN 84-3217605" \
+HOUSTON_ORG_JURISDICTION="US" \
+HOUSTON_ORG_BUSINESS_TYPE="company" \
+bundle exec bin/rails beltic:bootstrap_business_credential
+```
+
+The task prints:
+
+```
+BELTIC_ORG_CREDENTIAL_ID=cred_abc123…
+BELTIC_ORG_SUBJECT_ID=org_houston_a8f3…
+```
+
+Copy both into `.env`. Houston needs the subject_id as `parent_business_id` on
+every downstream user/agent credential, and the credential_id for its own
+records.
+
+Verify config:
+
+```bash
+bundle exec bin/rails beltic:config
+```
+
+## 5. Start Houston
+
+```bash
+bundle exec bin/rails server
+```
+
+Browse to **http://localhost:3000**. Sign up (or use Devise's invitation flow if
+you've seeded an admin), then visit:
+
+- `/identity/verify/new` — self-attestation flow
+- `/settings/identity` — your verified credential card
+- `/agents/new` — authorize an agent (requires verified identity)
+- `/settings/agents` — list of authorized agents
+
+Each form submission enqueues `Beltic::IssueCredentialJob`. The job calls Beltic
+at `http://localhost:8080/v1/credentials` and persists the returned credential
+into the `verifiable_credentials` table.
+
+Watch the logs side-by-side: Houston's `log/development.log` shows the outbound
+Faraday calls; the `pnpm dev` window shows Beltic's lambda processing them.
+
+## 6. (Optional) Subscribe to Beltic webhooks
+
+Beltic delivers `credential.revoked` / `credential.issued` / `credential.suspended`
+events to a URL you register. For local dev, expose Houston with ngrok:
+
+```bash
+ngrok http 3000
+# copy the https URL it prints, e.g. https://abc123.ngrok.io
+```
+
+Then:
+
+```bash
+BELTIC_WEBHOOK_URL=https://abc123.ngrok.io/webhooks/beltic \
+BELTIC_WEBHOOK_SECRET=$(openssl rand -hex 32) \
+bundle exec bin/rails beltic:subscribe_webhooks
+```
+
+Copy the printed `BELTIC_WEBHOOK_SECRET` into `.env` and restart the Rails server
+so `Webhooks::BelticController` can verify incoming signatures.
+
+To trigger a webhook, revoke a credential from the Beltic side:
+
+```bash
+curl -X POST http://localhost:8080/v1/credentials/cred_xxx/revoke \
+  -H "X-Api-Key: sk_staging_…" \
+  -H "Content-Type: application/json" \
+  -d '{"reason":"testing"}'
+```
+
+You should see the row in `verifiable_credentials` flip to `status=revoked`
+within a second or two.
+
+## 7. End-to-end smoke test
+
+Walk this happy path to confirm everything is wired:
+
+1. Sign up as `alice@example.com` in Houston.
+2. Visit `/identity/verify/new`. Submit:
+   - Nationality: US
+   - DOB: 1990-01-01
+   - ID document type: passport
+   - ID document country: US
+   - Check all three declarations.
+3. Job runs. Within 1–2s, `/settings/identity` shows the verified credential card with `trust_level: idv_verified`.
+4. Visit `/agents/new`. Create "Personal assistant" with daily limit $250, per-tx $100, currencies USD+BRL.
+5. Job runs. `/settings/agents` lists the agent with its credential ID.
+6. Revoke from Beltic (curl above). Webhook fires (if subscribed). `/settings/agents` shows revoked.
+7. Manually re-verify the agent's credential via the local Verifier:
+   ```ruby
+   # bundle exec bin/rails runner
+   vc = VerifiableCredential.last
+   Houston::Beltic.verifier.verify(vc.signed_payload, resource_type: "wallet",
+                                                       action: "checkout",
+                                                       transaction_amount: 5000,
+                                                       transaction_currency: "USD")
+   # => Result with valid?: true, reason: :ok (or :revoked if step 6 happened)
+   ```
+
+## Troubleshooting
+
+- **`unauthorized` / `forbidden` on issue** — API key missing scopes; recreate with `credentials:write`.
+- **`self_attestation_incomplete`** — the controller didn't set the flag because not all 3 declarations were checked.
+- **`delegated_by_required` on agent issue** — the user's credential ID isn't being resolved. Verify `current_user.beltic_user_credential&.active?` returns true.
+- **Webhook 401** — `BELTIC_WEBHOOK_SECRET` mismatch between what you sent to `subscribe_webhooks` and what's in `.env`. They must match exactly.
+- **JWKS fetch fails** — check `BELTIC_BASE_URL` matches the host serving `.well-known/`. If Beltic is on localhost, the jwks_url default (`api.beltic.com/.well-known/jwks.json`) is wrong — override `Houston::Beltic.config.jwks_url` in `config/initializers/beltic.rb` for local dev.
+- **`bin/rails db:migrate` complains about `lockbox`** — run `bundle install` to pick up the new gem.

--- a/docs/integrations/beltic.md
+++ b/docs/integrations/beltic.md
@@ -1,0 +1,236 @@
+# Beltic Verifiable Credentials Integration
+
+Status: design — implementation in progress on `beltic-integration` branch
+Owner: Beltic team (alivia@beltic.com)
+Design surfaces: https://www.figma.com/design/m9EpQoMdechc1XfFnCqA9I
+
+## Why
+
+Houston needs a portable, cryptographically-verifiable identity for two reasons:
+
+1. **End users**: prove who Houston's users are when their agents act on their behalf — especially when those agents make purchases, sign contracts, or otherwise spend money.
+2. **Houston itself (as an issuer)**: hold a Beltic-issued business credential so Houston can mint user and agent credentials under its own KYB-verified org identity.
+
+Beltic issues W3C JWT-VCs against a documented credentials API. Houston is the integrator: it owns the UI, owns the user data, and calls Beltic's API for issuance/verification.
+
+## Credential types we issue
+
+Three of Beltic's four credential types apply:
+
+| Type | Subject | When | Lifetime |
+|---|---|---|---|
+| `business` | Houston, Inc. (org) | One-time KYB at bootstrap | 1 yr, auto-renewed |
+| `user` | A Houston user | At signup OR first agent setup | 1 yr |
+| `agent_authorization` | An Agent the user has authorized | When user creates/authorizes an agent for purchases | bound to spend limits + idle timeout |
+
+We do **not** issue `outcome_attestation` directly in v1 — that's used by Beltic Workflows for KYB outcomes. We may use it later for credential-strengthening (see below).
+
+## End-to-end flow
+
+```
+                 ┌──────────────────────────────────────────────┐
+                 │  One-time: Houston bootstrap                  │
+                 │  rake beltic:bootstrap_business_credential    │
+                 │  → POST /v1/credentials (credential_type:     │
+                 │       business)                               │
+                 │  → stored in Houston.config.beltic.org_cred   │
+                 └──────────────────────────────────────────────┘
+
+User signup / first-agent setup:
+   User opens self-attestation modal in Houston (Figma: "Verify Your Identity")
+   → Houston collects: nationality, DOB, ID doc (optional), declarations
+   → POST /v1/credentials  (type: user, self_attestation_complete: true)
+   → store credential_id + signed_payload in verifiable_credentials table
+   → user.props['beltic.user_credential_id'] = ...
+
+User authorizes an agent:
+   User opens agent-authorization modal in Houston (Figma: "Authorize this agent")
+   → Houston collects: daily limit, per-tx max, currencies, idle duration,
+                       confirmation threshold
+   → POST /v1/credentials  (type: agent_authorization,
+                            delegated_by_subject_id: user_credential_id,
+                            permissions: [{ resource_type:'wallet',
+                                            actions:['checkout',
+                                                     'payment_authorize'], ... }])
+   → agent.props['beltic.agent_credential_id'] = ...
+
+Agent makes a purchase at runtime:
+   1. Agent constructs the purchase request and attaches its
+      signed_payload (the JWT-VC)
+   2. Houston's purchase handler calls Beltic::Verifier#verify(jwt, ctx)
+      - local verification via Beltic verifier SDK (sub-ms)
+      - validates: signature, not revoked, policy passes
+        (transaction_amount <= permissions.conditions['lte'], currency in
+         authorized_currencies, etc.)
+   3. If above the user's confirmation_threshold OR policy denies: emit a
+      Mission card to "Needs you" column for human approval
+   4. If verified + autonomous: complete the purchase, post the result as a
+      "Done" mission card with "Verified by Beltic" footer
+
+User revokes an agent OR re-verifies identity:
+   → POST /v1/credentials/{id}/revoke
+   → status flips, webhook fires, agent can no longer transact
+```
+
+## Components
+
+### Ruby Beltic client (`lib/houston/beltic/`)
+
+Houston is Ruby/Rails. Beltic's published SDK is TypeScript-only. We wrap their REST API via Faraday (already in Houston's Gemfile).
+
+- `Houston::Beltic` — module entry, configuration, ENV plumbing
+- `Houston::Beltic::Client` — Faraday HTTP wrapper, retries, `X-Api-Key` auth
+- `Houston::Beltic::Issuer` — typed `issue_business`, `issue_user`, `issue_agent_authorization` methods that build the right `subject`/`claims` shape per Beltic's schema
+- `Houston::Beltic::Verifier` — local JWT-VC verification using cached JWKS from `/.well-known/jwks.json`; falls back to server-side `POST /v1/credentials/:id/verify` when an audit trail is needed
+- `Houston::Beltic::WebhookVerifier` — HMAC-SHA256 (RFC 7797 detached JWT) verification of incoming webhook events
+- `Houston::Beltic::Errors` — typed exception hierarchy mirroring Beltic's error codes (`self_attestation_incomplete`, `kyb_required`, etc.)
+
+### Settings nav placement (Houston desktop app v0.4.12)
+
+Houston's Settings is a 3-pane layout: main sidebar → Settings sub-nav (Account, Workspace, Workspace context, User context, AI provider, Connect phone, Report bug) → content. Each content page stacks form sections vertically (heading, helper text, control), ending in a red Danger zone.
+
+The Beltic integration adds **two new Settings sub-nav items** following the existing pattern:
+
+- **Identity** — verified credential status, trust level, strengthening options (upload ID, add evidence, connect external accounts), revoke. Sections: "Your identity" / "Strengthen your identity" / "Recent activity" / "Danger zone (revoke credential)".
+- **Agents** — list of authorized agents, per-agent limits, audit log, revoke. Sections: "Authorized agents" / "Default limits for new agents" / "Recent purchase verifications" / "Danger zone (revoke all)".
+
+Why two items and not one combined "Identity & Agents": each Settings item in the existing app maps to a single concern. Splitting matches that convention and gives clean entry points for deep-linking from the agent-authorization modal ("revoke" → Settings/Agents) and from the verification card on a mission ("manage identity" → Settings/Identity).
+
+(Note: an earlier Figma mockup combined these into one card-heavy page. After this PR scaffolds the controllers, the mockup will be redone in the actual 3-pane Settings layout.)
+
+### Rails surfaces (`app/`)
+
+- `VerifiableCredential` model — one row per credential issued for a Houston user/agent. Stores `credential_id`, `credential_type`, `subject_id`, `status`, `expires_at`, `signed_payload` (encrypted at rest), `claims` (JSONB), `evidence_refs` (JSONB), `delegated_by_credential_id` (FK to another VC), timestamps.
+- `IdentityVerificationsController` — `new`/`create` for the self-attestation modal flow. On success, enqueues `Beltic::IssueCredentialJob`.
+- `AgentAuthorizationsController` — `new`/`create`/`destroy` for the per-agent consent flow. `destroy` calls revoke.
+- `IdentityStrengthenController` — `new`/`create` for **credential strengthening**: upload an ID document → re-issue user credential at a higher `trust_level`; upload professional credentials → issue stacked outcome credentials linked via `parent_user_id`. See "Credential strengthening" below.
+- `Webhooks::BelticController` — `create` endpoint receiving `credential.revoked`, `credential.suspended`, `credential.issued` callbacks. Verifies HMAC, updates the VC row, fires `Houston.observer.fire("beltic.credential_status_changed", ...)`.
+- `Beltic::IssueCredentialJob` — async wrapper around `Issuer#issue_*`. Retries with exponential backoff. On `self_attestation_incomplete` (422), it does NOT retry — surface the error to the user.
+
+### Config
+
+- `config/initializers/beltic.rb` — exposes `Houston.config.beltic { |b| b.api_key = ...; b.base_url = ...; b.org_credential_id = ...; b.webhook_secret = ... }`
+- ENV vars: `BELTIC_API_KEY`, `BELTIC_BASE_URL` (default `https://api.beltic.com/v1`), `BELTIC_WEBHOOK_SECRET`, `BELTIC_ORG_CREDENTIAL_ID`
+- Encrypted Rails credentials preferred over plain ENV in production (use `Rails.application.credentials.beltic`)
+
+### Data model additions
+
+```
+verifiable_credentials
+  id                          bigint pk
+  credential_id               string  uniq  not null  # Beltic-side ID, e.g. cred_a8f3...
+  credential_type             string  not null        # business | user | agent_authorization
+  subject_type                string  not null        # User | Agent | Organization
+  subject_id                  bigint  not null
+  status                      string  not null        # active | suspended | revoked | expired
+  signed_payload              text    encrypted       # JWT-VC
+  claims                      jsonb   not null
+  evidence_refs               jsonb   default '[]'
+  delegated_by_credential_id  bigint  fk (self)       # for agent VCs, points to user VC
+  issued_at                   timestamp
+  expires_at                  timestamp
+  revoked_at                  timestamp
+  raw_response                jsonb                   # full Beltic API response, for audit
+  created_at, updated_at
+
+  indexes:
+    (subject_type, subject_id)
+    (credential_id) unique
+    (status)
+    (expires_at) where status = 'active'
+
+agents (new table — Houston doesn't have one yet)
+  id                          bigint pk
+  user_id                     bigint fk users
+  name                        string
+  did                         string  uniq            # did:jwk:... (subject DID)
+  status                      string                  # active | paused | revoked
+  spend_limit_amount_cents    integer
+  spend_limit_currency        string                  # ISO-4217
+  spend_limit_period          string                  # per_transaction | daily | weekly | monthly | lifetime
+  per_transaction_max_cents   integer
+  authorized_currencies       jsonb                   # ["USD","BRL"]
+  max_idle_duration_iso8601   string                  # PT4H
+  confirmation_threshold_cents integer                # cents above which to ask user; null = always or never (see flag)
+  confirmation_mode           string                  # always | threshold | never
+  created_at, updated_at
+
+users (additive columns only — no breaking changes)
+  beltic_user_credential_id   bigint fk verifiable_credentials   # current active user VC
+  beltic_trust_level          string                              # cached: self_attested|liveness_verified|idv_verified|enterprise_verified
+```
+
+## Credential strengthening (Settings → Identity)
+
+After initial issuance, the user's credential is at `trust_level: self_attested`. To raise it, the user can:
+
+1. **Upload a government ID** — triggers re-issuance of the user credential with `id_document_type`/`id_document_country` set and `trust_level: idv_verified`. The old credential is revoked atomically (Beltic guarantees status-list update before the new one returns).
+2. **Add supporting evidence** — receipts, address proofs, employer letters. These attach to the credential's `evidence_refs` array (each is a hash of the document stored encrypted; Beltic doesn't hold the doc, just the hash). Re-issues at the same trust level with a longer `evidence_refs` list.
+3. **Stack outcome attestations** — for things that aren't part of the base ID schema (LinkedIn profile, GitHub identity, professional license). These mint a separate `outcome_attestation` credential with `parent_user_id` pointing back to the user's main credential. Surfaced together in Settings as a list of attached attestations.
+
+UI shape: Settings → Identity & Agents page gains a new section "Strengthen your identity" with the user's current trust level, a list of attached evidence/attestations, and "Upload ID", "Add evidence", "Connect external account" actions. Figma mockup to follow.
+
+API surface:
+- `POST /v1/credentials` again (revokes old, issues new) for ID upload / evidence
+- `POST /v1/credentials` with `credential_type: outcome_attestation, subject.parent_user_id: <user_cred_id>` for stacked attestations
+- `POST /v1/credentials/{old_id}/revoke` is implicit in the re-issuance flow
+
+## Routes (to add to `config/routes.rb`)
+
+```ruby
+# Identity verification
+resource :identity_verification, only: [:new, :create]
+resource :identity_strengthening, only: [:new, :create]
+
+# Agent authorization
+resources :agents do
+  resource :authorization, only: [:new, :create, :destroy], controller: "agent_authorizations"
+end
+
+# Webhooks
+namespace :webhooks do
+  resource :beltic, only: [:create]
+end
+```
+
+## Security considerations
+
+- `signed_payload` stored encrypted-at-rest (`attr_encrypted` or Rails 7+ encrypted attributes — currently 6.0, will need `attr_encrypted` gem)
+- Webhook endpoint verifies HMAC signature BEFORE deserializing JSON; reject mismatched signatures with 401
+- API key in ENV/credentials only — never in code, never in logs (Faraday redactor on `X-Api-Key` header)
+- Verifier caches JWKS with respect for `Cache-Control`; force-refresh on a key-id miss
+- `delegated_by_subject_id` is REQUIRED by Beltic when an agent's permissions include `resource_type: "wallet"` (FinCEN AML) — Issuer validates this client-side too
+- Rate limit the user-facing self-attestation endpoint (prevent attestation spamming → cost)
+
+## Phasing
+
+| Phase | Scope | Status |
+|---|---|---|
+| 0 | Ruby client + business credential bootstrap + Settings → Identity card | this PR |
+| 1 | User self-attestation flow + verifiable_credentials table | this PR |
+| 2 | Agents table + agent_authorization issuance + Settings → Agents list | this PR |
+| 3 | Purchase-time verifier hook in Houston's mission/purchase pipeline | follow-up |
+| 4 | Credential strengthening (Settings → Strengthen your identity) | follow-up |
+| 5 | Webhooks → credential status sync | follow-up |
+| 6 | Recovery flows (lost device, agent compromise, key rotation) | later |
+
+## What's in this PR (initial scaffold)
+
+- This design doc
+- `lib/houston/beltic/` skeleton (client, issuer, verifier, webhook_verifier, errors)
+- `config/initializers/beltic.rb` with config block
+- `app/models/verifiable_credential.rb` + migration
+- `app/models/agent.rb` + migration
+- Controller stubs: `identity_verifications`, `agent_authorizations`, `webhooks/beltic`
+- Job stub: `beltic/issue_credential_job`
+- `.env.example` documenting required ENV vars
+
+None of these files are wired into routes yet — `config/routes.rb` is unchanged. Wiring happens in follow-up commits on the same branch after the scaffold is reviewed.
+
+## References
+
+- Beltic platform repo: `/Users/sophiacastor/Documents/Work/Beltic/platform`
+- Beltic credentials API: `apps/api/credentials/` in the Beltic platform repo
+- Beltic schemas: `packages/schemas/src/credentials/`
+- Self-attestation integration guide: `docs/credentials-self-attestation-integration-guide.md` (in Beltic platform)
+- Figma design surfaces: https://www.figma.com/design/m9EpQoMdechc1XfFnCqA9I (page "v2 — Houston Desktop")

--- a/houston-core.gemspec
+++ b/houston-core.gemspec
@@ -36,6 +36,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "devise_invitable"
   spec.add_dependency "faraday"
   spec.add_dependency "faraday-http-cache"
+
+  # Beltic verifiable-credentials integration
+  spec.add_dependency "jwt", "~> 2.7"
+  spec.add_dependency "lockbox", "~> 1.3"
   spec.add_dependency "gemoji", "~> 2.1.0"
   spec.add_dependency "handlebars_assets", "~> 0.23.0"
   spec.add_dependency "mail"

--- a/lib/houston/beltic.rb
+++ b/lib/houston/beltic.rb
@@ -7,21 +7,38 @@ require "houston/beltic/webhook_verifier"
 module Houston
   module Beltic
     class Configuration
-      attr_accessor :api_key, :base_url, :webhook_secret, :org_credential_id,
+      attr_accessor :api_key, :base_url, :webhook_secret,
+                    :org_credential_id, :org_subject_id,
                     :issuer_did, :jwks_url, :status_list_url,
                     :request_timeout, :open_timeout
 
       def initialize
         @base_url        = "https://api.beltic.com/v1"
         @issuer_did      = "did:web:beltic.com"
-        @jwks_url        = "https://api.beltic.com/.well-known/jwks.json"
-        @status_list_url = "https://api.beltic.com/.well-known/status-lists/v1"
         @request_timeout = 10
         @open_timeout    = 5
       end
 
       def configured?
         !api_key.nil? && !api_key.empty?
+      end
+
+      # Derive well-known URLs from base_url unless explicitly overridden.
+      # Lets BELTIC_BASE_URL=http://localhost:8080/v1 just work without setting
+      # jwks_url / status_list_url separately.
+      def jwks_url
+        @jwks_url ||= well_known("jwks.json")
+      end
+
+      def status_list_url
+        @status_list_url ||= well_known("status-lists/v1")
+      end
+
+      private
+
+      def well_known(suffix)
+        origin = base_url.to_s.sub(%r{/v\d+/?\z}, "")
+        "#{origin}/.well-known/#{suffix}"
       end
     end
 

--- a/lib/houston/beltic.rb
+++ b/lib/houston/beltic.rb
@@ -1,0 +1,54 @@
+require "houston/beltic/errors"
+require "houston/beltic/client"
+require "houston/beltic/issuer"
+require "houston/beltic/verifier"
+require "houston/beltic/webhook_verifier"
+
+module Houston
+  module Beltic
+    class Configuration
+      attr_accessor :api_key, :base_url, :webhook_secret, :org_credential_id,
+                    :issuer_did, :jwks_url, :status_list_url,
+                    :request_timeout, :open_timeout
+
+      def initialize
+        @base_url        = "https://api.beltic.com/v1"
+        @issuer_did      = "did:web:beltic.com"
+        @jwks_url        = "https://api.beltic.com/.well-known/jwks.json"
+        @status_list_url = "https://api.beltic.com/.well-known/status-lists/v1"
+        @request_timeout = 10
+        @open_timeout    = 5
+      end
+
+      def configured?
+        !api_key.nil? && !api_key.empty?
+      end
+    end
+
+    class << self
+      def config
+        @config ||= Configuration.new
+      end
+
+      def configure
+        yield(config)
+      end
+
+      def client
+        @client ||= Client.new(config)
+      end
+
+      def issuer
+        @issuer ||= Issuer.new(client)
+      end
+
+      def verifier
+        @verifier ||= Verifier.new(config)
+      end
+
+      def reset!
+        @client = @issuer = @verifier = nil
+      end
+    end
+  end
+end

--- a/lib/houston/beltic/client.rb
+++ b/lib/houston/beltic/client.rb
@@ -1,0 +1,80 @@
+require "faraday"
+require "json"
+
+module Houston
+  module Beltic
+    class Client
+      attr_reader :config
+
+      def initialize(config)
+        raise ConfigurationError, "Beltic api_key is not set" unless config.configured?
+        @config = config
+      end
+
+      def post(path, body)
+        request(:post, path, body)
+      end
+
+      def get(path, params = {})
+        request(:get, path, nil, params)
+      end
+
+      def delete(path)
+        request(:delete, path)
+      end
+
+      private
+
+      def request(method, path, body = nil, params = {})
+        response = connection.public_send(method) do |req|
+          req.url(path)
+          req.params.update(params) if params && !params.empty?
+          if body
+            req.headers["Content-Type"] = "application/json"
+            req.body = body.is_a?(String) ? body : JSON.generate(body)
+          end
+        end
+
+        handle_response(response)
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+        raise TransportError.new(e.message, raw: e)
+      end
+
+      def handle_response(response)
+        body = parse_body(response.body)
+
+        case response.status
+        when 200..299
+          body
+        else
+          code    = body.is_a?(Hash) ? body["error_code"] : nil
+          message = body.is_a?(Hash) ? body["error_message"] || body["message"] : response.body
+          raise Houston::Beltic.error_for(
+            code:        code,
+            message:     message || "Beltic API error",
+            http_status: response.status,
+            raw:         body,
+          )
+        end
+      end
+
+      def parse_body(raw)
+        return {} if raw.nil? || raw.empty?
+        JSON.parse(raw)
+      rescue JSON::ParserError
+        raw
+      end
+
+      def connection
+        @connection ||= Faraday.new(url: config.base_url) do |f|
+          f.headers["X-Api-Key"]    = config.api_key
+          f.headers["User-Agent"]   = "houston-core (beltic-integration)"
+          f.headers["Accept"]       = "application/json"
+          f.options.timeout         = config.request_timeout
+          f.options.open_timeout    = config.open_timeout
+          f.adapter Faraday.default_adapter
+        end
+      end
+    end
+  end
+end

--- a/lib/houston/beltic/client.rb
+++ b/lib/houston/beltic/client.rb
@@ -47,8 +47,11 @@ module Houston
         when 200..299
           body
         else
-          code    = body.is_a?(Hash) ? body["error_code"] : nil
-          message = body.is_a?(Hash) ? body["error_message"] || body["message"] : response.body
+          # Beltic's error envelope: { "error": { "code", "message", "details", "request_id" } }
+          # Older endpoints occasionally still flatten to top-level keys; tolerate both.
+          err = body.is_a?(Hash) ? (body["error"] || body) : {}
+          code    = err["code"] || err["error_code"]
+          message = err["message"] || err["error_message"] || response.body
           raise Houston::Beltic.error_for(
             code:        code,
             message:     message || "Beltic API error",

--- a/lib/houston/beltic/errors.rb
+++ b/lib/houston/beltic/errors.rb
@@ -32,15 +32,26 @@ module Houston
     class PolicyDeniedError < VerificationError; end
     class WebhookSignatureError < Error; end
 
+    # Maps Beltic's `error.code` strings (see Beltic platform: packages/schemas/src/credentials/shared/responses.ts)
+    # to typed exception classes.
     ERROR_CODE_MAP = {
       "self_attestation_incomplete" => SelfAttestationIncompleteError,
+      "validation_failed"           => SchemaValidationError,
+      "malformed_request"           => SchemaValidationError,
+      "missing_required_field"      => SchemaValidationError,
+      "unauthorized"                => AuthenticationError,
+      "forbidden"                   => PermissionError,
+      "not_found"                   => NotFoundError,
+      "conflict"                    => APIError,
+      "idempotency_key_conflict"    => APIError,
+      "unprocessable_entity"        => APIError,
+      "internal_error"              => ServerError,
+      "upstream_error"              => ServerError,
+      "kms_signing_failed"          => ServerError,
+      "database_error"              => ServerError,
+      # Domain-level codes Houston may emit client-side or that Beltic returns in some flows
       "kyb_required"                => KYBRequiredError,
       "delegated_by_required"       => DelegationMissingError,
-      "schema_validation_failed"    => SchemaValidationError,
-      "authentication_failed"       => AuthenticationError,
-      "permission_denied"           => PermissionError,
-      "not_found"                   => NotFoundError,
-      "rate_limited"                => RateLimitError,
     }.freeze
 
     def self.error_for(code:, message:, http_status:, raw: nil)

--- a/lib/houston/beltic/errors.rb
+++ b/lib/houston/beltic/errors.rb
@@ -1,0 +1,61 @@
+module Houston
+  module Beltic
+    class Error < StandardError
+      attr_reader :code, :http_status, :raw
+
+      def initialize(message, code: nil, http_status: nil, raw: nil)
+        super(message)
+        @code        = code
+        @http_status = http_status
+        @raw         = raw
+      end
+    end
+
+    class ConfigurationError < Error; end
+    class TransportError < Error; end
+
+    class APIError < Error; end
+    class AuthenticationError < APIError; end
+    class PermissionError < APIError; end
+    class NotFoundError < APIError; end
+    class RateLimitError < APIError; end
+    class ServerError < APIError; end
+
+    class SelfAttestationIncompleteError < APIError; end
+    class KYBRequiredError < APIError; end
+    class DelegationMissingError < APIError; end
+    class SchemaValidationError < APIError; end
+
+    class VerificationError < Error; end
+    class RevokedError < VerificationError; end
+    class ExpiredError < VerificationError; end
+    class PolicyDeniedError < VerificationError; end
+    class WebhookSignatureError < Error; end
+
+    ERROR_CODE_MAP = {
+      "self_attestation_incomplete" => SelfAttestationIncompleteError,
+      "kyb_required"                => KYBRequiredError,
+      "delegated_by_required"       => DelegationMissingError,
+      "schema_validation_failed"    => SchemaValidationError,
+      "authentication_failed"       => AuthenticationError,
+      "permission_denied"           => PermissionError,
+      "not_found"                   => NotFoundError,
+      "rate_limited"                => RateLimitError,
+    }.freeze
+
+    def self.error_for(code:, message:, http_status:, raw: nil)
+      klass = ERROR_CODE_MAP[code] || begin
+        case http_status
+        when 401      then AuthenticationError
+        when 403      then PermissionError
+        when 404      then NotFoundError
+        when 422      then SchemaValidationError
+        when 429      then RateLimitError
+        when 500..599 then ServerError
+        else               APIError
+        end
+      end
+      klass.new(message, code: code, http_status: http_status, raw: raw)
+    end
+  end
+end

--- a/lib/houston/beltic/issuer.rb
+++ b/lib/houston/beltic/issuer.rb
@@ -1,0 +1,80 @@
+module Houston
+  module Beltic
+    class Issuer
+      def initialize(client)
+        @client = client
+      end
+
+      # Issue Houston's own business credential (one-time KYB bootstrap).
+      def issue_business(subject:, claims:, ttl: "P1Y")
+        post_credential(
+          credential_type: "business",
+          self_attestation_complete: true,
+          subject: subject,
+          claims:  claims,
+          ttl:     ttl,
+        )
+      end
+
+      # Issue a user credential after the user completes self-attestation.
+      def issue_user(subject:, claims:, evidence_refs: [], ttl: "P1Y")
+        post_credential(
+          credential_type: "user",
+          self_attestation_complete: true,
+          subject:       subject,
+          claims:        claims,
+          evidence_refs: evidence_refs,
+          ttl:           ttl,
+        )
+      end
+
+      # Issue an agent_authorization credential delegating from a user to an agent.
+      # Beltic REQUIRES delegated_by_subject_id when any permission.resource_type == "wallet"
+      # (FinCEN AML). We enforce this client-side too.
+      def issue_agent_authorization(subject:, claims:, ttl: nil)
+        validate_delegation!(claims)
+        body = {
+          credential_type: "agent_authorization",
+          self_attestation_complete: true,
+          subject: subject,
+          claims:  claims,
+        }
+        body[:ttl] = ttl if ttl
+        post_credential(body)
+      end
+
+      def revoke(credential_id, reason: nil)
+        body = reason ? { reason: reason } : {}
+        @client.post("/credentials/#{credential_id}/revoke", body)
+      end
+
+      def get(credential_id)
+        @client.get("/credentials/#{credential_id}")
+      end
+
+      private
+
+      def post_credential(body)
+        @client.post("/credentials", body)
+      end
+
+      def validate_delegation!(claims)
+        permissions = claims[:permissions] || claims["permissions"] || []
+        return if permissions.empty?
+
+        wallet_scoped = permissions.any? do |p|
+          (p[:resource_type] || p["resource_type"]) == "wallet"
+        end
+        return unless wallet_scoped
+
+        delegated = claims[:delegated_by_subject_id] || claims["delegated_by_subject_id"]
+        return if delegated && !delegated.to_s.empty?
+
+        raise DelegationMissingError.new(
+          "agent_authorization with wallet-scoped permissions requires delegated_by_subject_id (FinCEN AML)",
+          code: "delegated_by_required",
+        )
+      end
+    end
+  end
+end

--- a/lib/houston/beltic/verifier.rb
+++ b/lib/houston/beltic/verifier.rb
@@ -1,0 +1,41 @@
+module Houston
+  module Beltic
+    # Verifies a Beltic-issued JWT-VC. Two paths:
+    #
+    #   - Local (`verify`): sub-ms, no network at transaction time. Uses cached JWKS
+    #     and the Status List 2021 bitstring. Use this in the hot purchase path.
+    #
+    #   - Server-side (`verify_remote!`): calls POST /v1/credentials/:id/verify on
+    #     Beltic, producing an audit-trail event. Use this for compliance-sensitive
+    #     operations or when you want every verification logged centrally.
+    #
+    # NOTE: this is a stub. Full local verification requires the JWKS cache, the
+    # status list bitstring fetcher, JWT signature verification, and the
+    # permission-policy evaluator. Each is its own file; ticket out as Phase 3.
+    class Verifier
+      attr_reader :config
+
+      def initialize(config)
+        @config = config
+      end
+
+      # Local verification. ctx contains the transaction details to evaluate
+      # against the credential's permission conditions (e.g.,
+      # { resource_type: "wallet", action: "checkout",
+      #   transaction_amount: 5000, transaction_currency: "USD" }).
+      def verify(_jwt, _ctx = {})
+        raise NotImplementedError, "Local verifier not yet implemented — see Phase 3"
+      end
+
+      # Server-side verification with audit trail.
+      def verify_remote!(credential_id, ctx = {})
+        Houston::Beltic.client.post("/credentials/#{credential_id}/verify", ctx)
+      end
+
+      # Invalidate cached JWKS (call after a key-id miss).
+      def invalidate_jwks!
+        @jwks_cache = nil
+      end
+    end
+  end
+end

--- a/lib/houston/beltic/verifier.rb
+++ b/lib/houston/beltic/verifier.rb
@@ -1,30 +1,81 @@
+require "jwt"
+require "faraday"
+require "json"
+require "base64"
+require "zlib"
+require "stringio"
+
 module Houston
   module Beltic
-    # Verifies a Beltic-issued JWT-VC. Two paths:
+    # Verifies a Beltic-issued JWT-VC.
     #
-    #   - Local (`verify`): sub-ms, no network at transaction time. Uses cached JWKS
-    #     and the Status List 2021 bitstring. Use this in the hot purchase path.
+    # Two paths:
     #
-    #   - Server-side (`verify_remote!`): calls POST /v1/credentials/:id/verify on
-    #     Beltic, producing an audit-trail event. Use this for compliance-sensitive
-    #     operations or when you want every verification logged centrally.
+    #   - Local (`verify`): sub-ms after warm cache. Pulls JWKS once from
+    #     /.well-known/jwks.json, the Status List 2021 bitstring from
+    #     /.well-known/status-lists/v1, verifies the JWT signature against the
+    #     matching key, checks revocation against the bitstring, and evaluates
+    #     the permission policy against the supplied transaction context. Use
+    #     in the hot purchase path.
     #
-    # NOTE: this is a stub. Full local verification requires the JWKS cache, the
-    # status list bitstring fetcher, JWT signature verification, and the
-    # permission-policy evaluator. Each is its own file; ticket out as Phase 3.
+    #   - Remote (`verify_remote!`): POST /v1/credentials/:id/verify on Beltic,
+    #     producing an audit-trail event. Use for compliance-sensitive ops.
+    #
+    # Result object:
+    #
+    #   r = verifier.verify(jwt, resource_type: "wallet", action: "checkout",
+    #                            transaction_amount: 9900, transaction_currency: "USD")
+    #   r.valid?    # => true / false
+    #   r.reason    # => :ok | :expired | :revoked | :policy_denied | :bad_signature | ...
+    #   r.payload   # => parsed JWT payload (claims) when signature was good
+    #
     class Verifier
       attr_reader :config
 
+      Result = Struct.new(:valid?, :reason, :payload, :detail, keyword_init: true) do
+        def ok?;          reason == :ok end
+        def to_h;         { valid: valid?, reason: reason, detail: detail } end
+      end
+
       def initialize(config)
         @config = config
+        @jwks_cache = nil
+        @jwks_fetched_at = nil
+        @jwks_max_age = 600 # seconds; respect Cache-Control when present
+        @status_list_cache = nil
+        @status_list_fetched_at = nil
+        @status_list_max_age = 60
       end
 
       # Local verification. ctx contains the transaction details to evaluate
-      # against the credential's permission conditions (e.g.,
-      # { resource_type: "wallet", action: "checkout",
-      #   transaction_amount: 5000, transaction_currency: "USD" }).
-      def verify(_jwt, _ctx = {})
-        raise NotImplementedError, "Local verifier not yet implemented — see Phase 3"
+      # against the credential's permission conditions, e.g.:
+      #   { resource_type: "wallet", action: "checkout",
+      #     transaction_amount: 5000, transaction_currency: "USD" }
+      def verify(jwt, ctx = {})
+        header, payload = decode_unverified(jwt)
+        return Result.new(valid?: false, reason: :malformed, detail: "could not decode JWT") if header.nil?
+
+        kid = header["kid"]
+        jwk = find_key(kid)
+        return Result.new(valid?: false, reason: :unknown_kid, detail: "no key for kid=#{kid}") unless jwk
+
+        verified_payload = verify_signature!(jwt, jwk)
+        return Result.new(valid?: false, reason: :bad_signature) unless verified_payload
+
+        if expired?(verified_payload)
+          return Result.new(valid?: false, reason: :expired, payload: verified_payload)
+        end
+
+        if revoked?(verified_payload)
+          return Result.new(valid?: false, reason: :revoked, payload: verified_payload)
+        end
+
+        policy = evaluate_policy(verified_payload, ctx)
+        unless policy[:ok]
+          return Result.new(valid?: false, reason: :policy_denied, payload: verified_payload, detail: policy[:detail])
+        end
+
+        Result.new(valid?: true, reason: :ok, payload: verified_payload)
       end
 
       # Server-side verification with audit trail.
@@ -32,9 +83,168 @@ module Houston
         Houston::Beltic.client.post("/credentials/#{credential_id}/verify", ctx)
       end
 
-      # Invalidate cached JWKS (call after a key-id miss).
       def invalidate_jwks!
         @jwks_cache = nil
+      end
+
+      def invalidate_status_list!
+        @status_list_cache = nil
+      end
+
+      private
+
+      def decode_unverified(jwt)
+        header, payload, _sig = jwt.to_s.split(".")
+        return [nil, nil] if header.nil? || payload.nil?
+        [JSON.parse(b64u_decode(header)), JSON.parse(b64u_decode(payload))]
+      rescue JSON::ParserError, ArgumentError
+        [nil, nil]
+      end
+
+      def b64u_decode(str)
+        # JWT uses base64url without padding.
+        padding = "=" * ((4 - str.length % 4) % 4)
+        Base64.urlsafe_decode64(str + padding)
+      end
+
+      def verify_signature!(jwt, jwk)
+        key = ::JWT::JWK.import(jwk).verify_key
+        decoded, _ = ::JWT.decode(jwt, key, true, algorithm: jwk["alg"] || "ES256")
+        decoded
+      rescue ::JWT::DecodeError, ::JWT::VerificationError
+        nil
+      end
+
+      def find_key(kid)
+        load_jwks!
+        (@jwks_cache || []).find { |k| k["kid"] == kid }
+      end
+
+      def load_jwks!
+        return @jwks_cache if @jwks_cache && fresh?(@jwks_fetched_at, @jwks_max_age)
+
+        response = Faraday.get(config.jwks_url)
+        raise VerificationError, "JWKS fetch failed: #{response.status}" unless response.success?
+        body = JSON.parse(response.body)
+        @jwks_cache = body["keys"] || []
+        @jwks_fetched_at = Time.now
+
+        cache_control_max_age(response.headers).tap do |max|
+          @jwks_max_age = max if max
+        end
+
+        @jwks_cache
+      end
+
+      def cache_control_max_age(headers)
+        cc = headers["cache-control"] || headers["Cache-Control"]
+        return nil unless cc
+        m = cc.match(/max-age=(\d+)/)
+        m && m[1].to_i
+      end
+
+      def fresh?(fetched_at, max_age)
+        fetched_at && (Time.now - fetched_at) < max_age
+      end
+
+      def expired?(payload)
+        exp = payload["exp"]
+        return false unless exp
+        Time.at(exp) < Time.now
+      end
+
+      # Beltic uses W3C Status List 2021 — a gzip+base64-encoded bitstring where
+      # bit `statusListIndex` for credential's `statusListCredential` indicates
+      # revocation (1 = revoked).
+      def revoked?(payload)
+        status = payload.dig("vc", "credentialStatus") || payload["credentialStatus"]
+        return false unless status
+
+        index = status["statusListIndex"].to_i
+        list_url = status["statusListCredential"] || config.status_list_url
+        bitstring = load_status_list!(list_url)
+        return false unless bitstring
+
+        byte_index = index / 8
+        bit_in_byte = 7 - (index % 8)
+        return false if byte_index >= bitstring.bytesize
+
+        ((bitstring.getbyte(byte_index) >> bit_in_byte) & 1) == 1
+      end
+
+      def load_status_list!(url)
+        return @status_list_cache if @status_list_cache && fresh?(@status_list_fetched_at, @status_list_max_age) && @status_list_url_used == url
+
+        response = Faraday.get(url)
+        raise VerificationError, "Status List fetch failed: #{response.status}" unless response.success?
+        body = JSON.parse(response.body)
+        encoded = body.dig("credentialSubject", "encodedList") || body["encodedList"]
+        return nil unless encoded
+
+        gz = b64u_decode(encoded)
+        @status_list_cache = Zlib::GzipReader.new(StringIO.new(gz)).read
+        @status_list_fetched_at = Time.now
+        @status_list_url_used = url
+        @status_list_cache
+      end
+
+      # Evaluates the credential's claims.permissions array against the
+      # transaction context. A permission matches if its resource_type and one
+      # of its actions match, and every condition in its conditions array
+      # passes.
+      def evaluate_policy(payload, ctx)
+        return { ok: true, detail: "no context to evaluate" } if ctx.nil? || ctx.empty?
+
+        ctx = ctx.transform_keys(&:to_s)
+        claims = payload.dig("vc", "credentialSubject", "claims") || payload["claims"] || {}
+        permissions = claims["permissions"] || []
+        return { ok: false, detail: "credential has no permissions" } if permissions.empty?
+
+        matching = permissions.select { |p| permission_matches?(p, ctx) }
+        return { ok: false, detail: "no permission grants this resource/action" } if matching.empty?
+
+        failures = matching.flat_map { |p| failing_conditions(p, ctx) }.compact
+        return { ok: false, detail: "conditions denied: #{failures.join(", ")}" } if failures.any?
+
+        spend_limit = claims["spend_limit"]
+        if spend_limit && ctx["transaction_amount"]
+          if ctx["transaction_amount"].to_i > spend_limit["amount"].to_i &&
+             spend_limit["period"] == "per_transaction"
+            return { ok: false, detail: "transaction_amount exceeds per-transaction spend_limit" }
+          end
+        end
+
+        { ok: true }
+      end
+
+      def permission_matches?(permission, ctx)
+        return false if permission["resource_type"] && permission["resource_type"] != ctx["resource_type"]
+        actions = permission["actions"] || []
+        return false if actions.any? && ctx["action"] && !actions.include?(ctx["action"])
+        true
+      end
+
+      OPS = {
+        "lte" => ->(a, b) { a.to_f <= b.to_f },
+        "lt"  => ->(a, b) { a.to_f <  b.to_f },
+        "gte" => ->(a, b) { a.to_f >= b.to_f },
+        "gt"  => ->(a, b) { a.to_f >  b.to_f },
+        "eq"  => ->(a, b) { a == b },
+        "neq" => ->(a, b) { a != b },
+        "in"  => ->(a, b) { Array(b).include?(a) },
+      }.freeze
+
+      def failing_conditions(permission, ctx)
+        (permission["conditions"] || []).map do |c|
+          op = c["operator"]
+          field = c["field"]
+          expected = c["value"]
+          actual = ctx[field]
+          checker = OPS[op]
+          if checker.nil? || actual.nil? || !checker.call(actual, expected)
+            "#{field} #{op} #{expected.inspect} (was #{actual.inspect})"
+          end
+        end.compact
       end
     end
   end

--- a/lib/houston/beltic/webhook_verifier.rb
+++ b/lib/houston/beltic/webhook_verifier.rb
@@ -1,42 +1,79 @@
 require "openssl"
-require "base64"
 
 module Houston
   module Beltic
     # Verifies the HMAC-SHA256 signature on incoming Beltic webhook events.
-    # Beltic signs using RFC 7797 detached JWT semantics — the signature header
-    # is "<algorithm>.<base64url(signature)>" and the signed payload is the raw
-    # request body.
+    #
+    # Beltic uses the Stripe-pattern signature format (see Beltic platform:
+    # apps/api/credentials/src/operations/audit/streams/hmac-sign.ts):
+    #
+    #   Beltic-Signature: sha256=<hex digest>
+    #   Beltic-Timestamp: <unix seconds>
+    #
+    # Signed payload is `"#{timestamp}.#{raw_body}"`. This binds the signature
+    # to a specific moment in time, preventing replay attacks. We reject any
+    # event whose timestamp differs from `Time.now` by more than `tolerance`
+    # seconds (default 300, matching Beltic's recommendation).
     class WebhookVerifier
-      SIGNATURE_HEADER = "X-Beltic-Signature".freeze
-      ALGORITHM        = "HS256".freeze
+      SIGNATURE_HEADER = "Beltic-Signature".freeze
+      TIMESTAMP_HEADER = "Beltic-Timestamp".freeze
 
-      def initialize(secret)
+      DEFAULT_TOLERANCE = 300 # seconds
+
+      def initialize(secret, tolerance: DEFAULT_TOLERANCE)
         raise ConfigurationError, "Beltic webhook_secret is not set" if secret.nil? || secret.empty?
-        @secret = secret
+        @secret    = secret
+        @tolerance = tolerance
       end
 
-      # Returns true if the signature is valid, false otherwise.
-      # Use this in a controller before parsing JSON.
-      def valid?(raw_body, signature_header)
-        return false if signature_header.nil? || signature_header.empty?
-
-        algo, encoded_sig = signature_header.split(".", 2)
-        return false unless algo == ALGORITHM && encoded_sig
-
-        expected = OpenSSL::HMAC.digest("SHA256", @secret, raw_body)
-        provided = Base64.urlsafe_decode64(encoded_sig)
-        secure_compare(expected, provided)
-      rescue ArgumentError
+      # Returns true if signature + timestamp are valid; false otherwise.
+      def valid?(raw_body, signature_header, timestamp_header)
+        verify!(raw_body, signature_header, timestamp_header)
+        true
+      rescue WebhookSignatureError
         false
       end
 
-      def verify!(raw_body, signature_header)
-        return if valid?(raw_body, signature_header)
-        raise WebhookSignatureError, "Invalid Beltic webhook signature"
+      def verify!(raw_body, signature_header, timestamp_header)
+        ts = parse_timestamp!(timestamp_header)
+        check_freshness!(ts)
+        provided = parse_signature!(signature_header)
+        expected = sign(ts, raw_body)
+        unless secure_compare(expected, provided)
+          raise WebhookSignatureError, "Beltic-Signature does not match expected HMAC"
+        end
+        true
       end
 
       private
+
+      def parse_timestamp!(header)
+        raise WebhookSignatureError, "Beltic-Timestamp header missing"   if header.nil? || header.empty?
+        raise WebhookSignatureError, "Beltic-Timestamp is not numeric"   unless header.to_s.match?(/\A\d+\z/)
+        header.to_i
+      end
+
+      def check_freshness!(ts)
+        delta = (Time.now.to_i - ts).abs
+        return if delta <= @tolerance
+        raise WebhookSignatureError, "Beltic-Timestamp #{ts} is outside the #{@tolerance}s tolerance (delta=#{delta}s)"
+      end
+
+      def parse_signature!(header)
+        raise WebhookSignatureError, "Beltic-Signature header missing" if header.nil? || header.empty?
+        unless header.start_with?("sha256=")
+          raise WebhookSignatureError, "Beltic-Signature must use sha256= prefix (got #{header.split('=').first})"
+        end
+        hex = header.sub(/\Asha256=/, "")
+        unless hex.match?(/\A[0-9a-f]+\z/i)
+          raise WebhookSignatureError, "Beltic-Signature hex digest malformed"
+        end
+        hex.downcase
+      end
+
+      def sign(ts, body)
+        OpenSSL::HMAC.hexdigest("SHA256", @secret, "#{ts}.#{body}")
+      end
 
       def secure_compare(a, b)
         return false unless a.bytesize == b.bytesize

--- a/lib/houston/beltic/webhook_verifier.rb
+++ b/lib/houston/beltic/webhook_verifier.rb
@@ -1,0 +1,50 @@
+require "openssl"
+require "base64"
+
+module Houston
+  module Beltic
+    # Verifies the HMAC-SHA256 signature on incoming Beltic webhook events.
+    # Beltic signs using RFC 7797 detached JWT semantics — the signature header
+    # is "<algorithm>.<base64url(signature)>" and the signed payload is the raw
+    # request body.
+    class WebhookVerifier
+      SIGNATURE_HEADER = "X-Beltic-Signature".freeze
+      ALGORITHM        = "HS256".freeze
+
+      def initialize(secret)
+        raise ConfigurationError, "Beltic webhook_secret is not set" if secret.nil? || secret.empty?
+        @secret = secret
+      end
+
+      # Returns true if the signature is valid, false otherwise.
+      # Use this in a controller before parsing JSON.
+      def valid?(raw_body, signature_header)
+        return false if signature_header.nil? || signature_header.empty?
+
+        algo, encoded_sig = signature_header.split(".", 2)
+        return false unless algo == ALGORITHM && encoded_sig
+
+        expected = OpenSSL::HMAC.digest("SHA256", @secret, raw_body)
+        provided = Base64.urlsafe_decode64(encoded_sig)
+        secure_compare(expected, provided)
+      rescue ArgumentError
+        false
+      end
+
+      def verify!(raw_body, signature_header)
+        return if valid?(raw_body, signature_header)
+        raise WebhookSignatureError, "Invalid Beltic webhook signature"
+      end
+
+      private
+
+      def secure_compare(a, b)
+        return false unless a.bytesize == b.bytesize
+        l = a.unpack("C#{a.bytesize}")
+        res = 0
+        b.each_byte { |byte| res |= byte ^ l.shift }
+        res.zero?
+      end
+    end
+  end
+end

--- a/lib/tasks/beltic.rake
+++ b/lib/tasks/beltic.rake
@@ -1,0 +1,77 @@
+namespace :beltic do
+  desc "Issue Houston's own business credential (one-time KYB bootstrap). Prints the credential_id to set as BELTIC_ORG_CREDENTIAL_ID."
+  task bootstrap_business_credential: :environment do
+    unless Houston::Beltic.config.configured?
+      abort "BELTIC_API_KEY is not set. Configure it before bootstrapping."
+    end
+
+    if Houston::Beltic.config.org_credential_id && !Houston::Beltic.config.org_credential_id.empty?
+      puts "[Beltic] BELTIC_ORG_CREDENTIAL_ID is already set: #{Houston::Beltic.config.org_credential_id}"
+      puts "[Beltic] Refusing to issue a new business credential. Revoke the existing one first if you really want to re-issue."
+      exit 0
+    end
+
+    org_name             = ENV.fetch("HOUSTON_ORG_NAME") { abort("Set HOUSTON_ORG_NAME") }
+    registration_number  = ENV.fetch("HOUSTON_ORG_REGISTRATION") { abort("Set HOUSTON_ORG_REGISTRATION (e.g. EIN 84-3217605)") }
+    jurisdiction         = ENV.fetch("HOUSTON_ORG_JURISDICTION", "US")
+    business_type        = ENV.fetch("HOUSTON_ORG_BUSINESS_TYPE", "company")
+
+    subject = {
+      type:                "organisation",
+      id:                  "org_houston_#{SecureRandom.hex(4)}",
+      registration_number: registration_number,
+      jurisdiction:        jurisdiction,
+    }
+
+    claims = {
+      kyb_status:        "pending",
+      business_type:     business_type,
+      jurisdiction:      jurisdiction,
+      registered_name:   org_name,
+      tax_id_verified:   false,
+    }
+
+    puts "[Beltic] Submitting business credential for #{org_name}…"
+    response = Houston::Beltic.issuer.issue_business(subject: subject, claims: claims)
+
+    credential_id = response["credential_id"] || response["id"]
+    puts ""
+    puts "[Beltic] Business credential issued."
+    puts "         credential_id:    #{credential_id}"
+    puts "         status:           #{response["status"]}"
+    puts "         expires_at:       #{response["expires_at"]}"
+    puts ""
+    puts "Set this in your environment so future user/agent credentials reference it as parent_business_id:"
+    puts ""
+    puts "  BELTIC_ORG_CREDENTIAL_ID=#{credential_id}"
+    puts ""
+
+    if defined?(VerifiableCredential)
+      VerifiableCredential.create!(
+        credential_id:   credential_id,
+        credential_type: "business",
+        subject_type:    "Organization",
+        subject_id:      0,
+        status:          response["status"] || "active",
+        signed_payload:  response["signed_payload"],
+        claims:          response["claims"] || claims,
+        issued_at:       response["issued_at"],
+        expires_at:      response["expires_at"],
+        raw_response:    response,
+      )
+      puts "[Beltic] Persisted to verifiable_credentials table."
+    end
+  end
+
+  desc "Print Beltic config (api_key redacted) for debugging."
+  task config: :environment do
+    c = Houston::Beltic.config
+    puts "configured?           #{c.configured?}"
+    puts "base_url:             #{c.base_url}"
+    puts "api_key:              #{c.api_key ? "sk_***#{c.api_key[-4..]}" : "(unset)"}"
+    puts "org_credential_id:    #{c.org_credential_id || "(unset)"}"
+    puts "webhook_secret:       #{c.webhook_secret ? "***" : "(unset)"}"
+    puts "issuer_did:           #{c.issuer_did}"
+    puts "jwks_url:             #{c.jwks_url}"
+  end
+end

--- a/lib/tasks/beltic.rake
+++ b/lib/tasks/beltic.rake
@@ -35,15 +35,18 @@ namespace :beltic do
     response = Houston::Beltic.issuer.issue_business(subject: subject, claims: claims)
 
     credential_id = response["credential_id"] || response["id"]
+    org_subject_id = response.dig("subject", "id") || subject[:id]
     puts ""
     puts "[Beltic] Business credential issued."
     puts "         credential_id:    #{credential_id}"
+    puts "         subject.id:       #{org_subject_id}"
     puts "         status:           #{response["status"]}"
     puts "         expires_at:       #{response["expires_at"]}"
     puts ""
-    puts "Set this in your environment so future user/agent credentials reference it as parent_business_id:"
+    puts "Set BOTH in your environment so future user/agent credentials reference them correctly:"
     puts ""
-    puts "  BELTIC_ORG_CREDENTIAL_ID=#{credential_id}"
+    puts "  BELTIC_ORG_CREDENTIAL_ID=#{credential_id}     # for our own records"
+    puts "  BELTIC_ORG_SUBJECT_ID=#{org_subject_id}       # passed as parent_business_id on user/agent credentials"
     puts ""
 
     if defined?(VerifiableCredential)
@@ -63,6 +66,37 @@ namespace :beltic do
     end
   end
 
+  desc "Register Houston's webhook endpoint with Beltic (POST /v1/audit/streams). Requires BELTIC_WEBHOOK_URL to be set to a publicly-reachable URL."
+  task subscribe_webhooks: :environment do
+    unless Houston::Beltic.config.configured?
+      abort "BELTIC_API_KEY is not set."
+    end
+
+    url = ENV.fetch("BELTIC_WEBHOOK_URL") do
+      abort("Set BELTIC_WEBHOOK_URL (publicly-reachable, e.g. https://houston.example.com/webhooks/beltic)")
+    end
+
+    secret = ENV["BELTIC_WEBHOOK_SECRET"]
+    if secret.nil? || secret.length < 32
+      secret = SecureRandom.hex(32)
+      puts "[Beltic] No BELTIC_WEBHOOK_SECRET set — generated one for you: #{secret}"
+      puts "         Set this as ENV BELTIC_WEBHOOK_SECRET so the controller can verify incoming events."
+    end
+
+    body = {
+      url:    url,
+      secret: secret,
+      event_filter: ENV.fetch("BELTIC_WEBHOOK_EVENTS", "credential.issued,credential.revoked,credential.suspended,credential.reactivated").split(","),
+    }
+
+    response = Houston::Beltic.client.post("/audit/streams", body)
+    puts "[Beltic] Webhook subscription created."
+    puts "         id:           #{response["id"]}"
+    puts "         url:          #{response["url"]}"
+    puts "         events:       #{response["event_filter"].inspect}"
+    puts "         active:       #{response["active"]}"
+  end
+
   desc "Print Beltic config (api_key redacted) for debugging."
   task config: :environment do
     c = Houston::Beltic.config
@@ -70,6 +104,7 @@ namespace :beltic do
     puts "base_url:             #{c.base_url}"
     puts "api_key:              #{c.api_key ? "sk_***#{c.api_key[-4..]}" : "(unset)"}"
     puts "org_credential_id:    #{c.org_credential_id || "(unset)"}"
+    puts "org_subject_id:       #{c.org_subject_id || "(unset)"}"
     puts "webhook_secret:       #{c.webhook_secret ? "***" : "(unset)"}"
     puts "issuer_did:           #{c.issuer_did}"
     puts "jwks_url:             #{c.jwks_url}"


### PR DESCRIPTION
## Summary

Scaffolds end-to-end identity verification for Houston via [Beltic](https://api.beltic.com). Houston becomes a Beltic issuer (its own KYB business credential) and mints user + agent_authorization credentials so that when an agent makes a purchase, it can present a cryptographically-verifiable delegation back to a real, verified human.

- **Ruby Beltic client** (`lib/houston/beltic/`) — Faraday-backed, typed errors mirroring Beltic's error codes, FinCEN delegation check on agent VCs
- **AR models + migrations** — `verifiable_credentials` (polymorphic subject, self-referencing for agent → user delegation chain), `agents` (new), additive columns on `users`
- **Controllers** — `IdentityVerificationsController` (self-attestation flow), `AgentAuthorizationsController` (per-agent spend-limit consent), `Webhooks::BelticController` (HMAC-verified status sync)
- **Async issuance job** — retry-on-transport, discard-on-schema; never silently retries past `self_attestation_incomplete`
- **Design doc** — `docs/integrations/beltic.md` covers architecture, credential types, Settings nav placement (matching the v0.4.12 3-pane layout), credential strengthening (`evidence_refs` + stacked outcome attestations), security, and phasing
- **Figma surfaces** — https://www.figma.com/design/m9EpQoMdechc1XfFnCqA9I (page "v2 — Houston Desktop")

## Intentionally not yet wired

- `config/routes.rb` is unchanged — the routes block to add is named in the design doc. Lands in a follow-up commit once the scaffold is reviewed.
- View templates aren't included — modal/page mockups exist in Figma; ERB to follow once nav structure is locked.
- `Verifier#verify` (local JWT-VC + status-list path) is stubbed with `NotImplementedError`. Phase 3 work.

## Test plan

- [ ] `bin/rails db:migrate` runs cleanly (3 new migrations)
- [ ] `bin/rails runner "p Houston::Beltic.config.configured?"` returns `false` without `BELTIC_API_KEY` set, `true` with it
- [ ] `VerifiableCredential.create!(...)` round-trips through the polymorphic subject + delegated_by self-FK
- [ ] `Houston::Beltic::Issuer#issue_agent_authorization` raises `DelegationMissingError` when given wallet-scoped permissions with no `delegated_by_subject_id`
- [ ] `Houston::Beltic::WebhookVerifier#valid?` rejects mismatched signatures (constant-time compare verified)
- [ ] Hooking the controllers into routes + writing the modal views (follow-up commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)